### PR TITLE
PR: Require PTYImpl trait to implement Send and Sync

### DIFF
--- a/src/pty/base.rs
+++ b/src/pty/base.rs
@@ -18,7 +18,7 @@ use std::os::windows::ffi::OsStrExt;
 use super::PTYArgs;
 
 /// This trait should be implemented by any backend that wants to provide a PTY implementation.
-pub trait PTYImpl {
+pub trait PTYImpl: Sync + Send {
     /// Create a new instance of the PTY backend.
     ///
     /// # Arguments

--- a/src/pty/conpty/pty_impl.rs
+++ b/src/pty/conpty/pty_impl.rs
@@ -41,6 +41,9 @@ pub struct ConPTY {
     process: PTYProcess
 }
 
+unsafe impl Send for ConPTY {}
+unsafe impl Sync for ConPTY {}
+
 impl PTYImpl for ConPTY {
     fn new(args: &PTYArgs) -> Result<Box<dyn PTYImpl>, OsString> {
         let mut result: HRESULT = S_OK;


### PR DESCRIPTION
This is required by pwyinpty in order to wrap the `PTY` struct in a PyO3 object.