### PR TITLE
Prevent iseof from returning immediately

### DIFF
--- a/src/pty/base.rs
+++ b/src/pty/base.rs
@@ -291,7 +291,7 @@ fn is_eof(process: HANDLE, stream: HANDLE) -> Result<bool, OsString> {
         let bytes_ptr: *mut u32 = ptr::addr_of_mut!(*bytes.as_mut_ptr());
         let bytes_ref = Some(bytes_ptr);
         let succ = PeekNamedPipe(
-            stream, None, 0, bytes_ref, None, None).as_bool();
+            stream, None, 0, None, bytes_ref, None).as_bool();
 
         let total_bytes = bytes.assume_init();
         if succ {


### PR DESCRIPTION
Since windows-rs now exposes the original C++ arguments, there was a minor confusion in which the total number of bytes remaining on the output stream handle was not being retrieved. Instead the function returned immediately since the total number of bytes to read was being set to a garbage value