### PR TITLE
fix: remove 100ms delay on first and subsequent read calls

### DIFF
--- a/src/pty/base.rs
+++ b/src/pty/base.rs
@@ -359,7 +359,7 @@ impl PTYProcess {
                 // let mut alive = reader_alive_rx.recv_timeout(Duration::from_millis(300)).unwrap_or(true);
                 // alive = alive && !is_eof(process, conout).unwrap();
 
-                while reader_alive_rx.recv_timeout(Duration::from_millis(100)).unwrap_or(true) {
+                while reader_alive_rx.try_recv().unwrap_or(true) {
                     if !is_eof(process, conout).unwrap() {
                         let result = read(4096, true, conout, using_pipes);
                         reader_out_tx.send(Some(result)).unwrap();
@@ -378,7 +378,7 @@ impl PTYProcess {
 
         let cache_thread = thread::spawn(move || {
             let mut read_buf = OsString::new();
-            while cache_alive_rx.recv_timeout(Duration::from_millis(100)).unwrap_or(true) {
+            while cache_alive_rx.try_recv().unwrap_or(true) {
                 if let Ok(Some((length, blocking))) = cache_req_rx.recv() {
                     let mut pending_read: Option<OsString> = None;
 


### PR DESCRIPTION
Currently, there is an unnecessary wait with `recv_timeout()` on reader thread and cache thread.

On reader thread, it causes reading from pipe to have an inherent 100ms wait time between each chunk read.
Similarly, cache thread also has this issue, where read() calls are served throttled with a 100ms delay.

This PR replaces `recv_timeout` with `try_recv` so all read() calls will return as soon as possible.

Fixes #75 