### PR TITLE
use Arc + Mutex insted of Box

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ parking_lot = "0.12.3"
 which = "7.0.0"
 
 [dependencies.windows]
-version = "0.59.0"
+version = "0.60.0"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winpty-rs"
-version = "0.4.1-dev"
+version = "0.4.2"
 edition = "2021"
 links = "winpty"
 license = "MIT OR Apache-2.0"
@@ -31,15 +31,12 @@ features = [
     "Win32_Globalization",
     # ConPTY-specific
     "Win32_System_Console",
-    "Win32_UI_WindowsAndMessaging"
+    "Win32_UI_WindowsAndMessaging",
 ]
 
 [build-dependencies.windows]
 version = "0.58.0"
-features = [
-    "Win32_Foundation",
-    "Win32_System_LibraryLoader"
-]
+features = ["Win32_Foundation", "Win32_System_LibraryLoader"]
 
 [dev-dependencies]
 regex = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["windows", "pty", "winpty", "conpty", "pseudoterminal"]
 enum-primitive-derive = "0.3.0"
 num-traits = "0.2"
 bitflags = "2.3"
+parking_lot = "0.12.3"
 
 [build-dependencies]
 which = "7.0.0"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,11 @@
-#[cfg(windows)]
-use windows::Win32::System::LibraryLoader::{GetProcAddress, GetModuleHandleW};
-#[cfg(windows)]
-use windows::core::{PWSTR, PSTR, PCWSTR, PCSTR, HSTRING};
 use std::i64;
 use std::process::Command;
 use std::str;
 use which::which;
+#[cfg(windows)]
+use windows::core::{HSTRING, PCSTR, PCWSTR, PSTR, PWSTR};
+#[cfg(windows)]
+use windows::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
 
 #[cfg(windows)]
 trait IntoPWSTR {
@@ -30,10 +30,7 @@ trait IntoPCWSTR {
 #[cfg(windows)]
 impl IntoPCWSTR for &str {
     fn into_pcwstr(self) -> PCWSTR {
-        let encoded = self
-            .encode_utf16()
-            .chain([0u16])
-            .collect::<Vec<u16>>();
+        let encoded = self.encode_utf16().chain([0u16]).collect::<Vec<u16>>();
 
         PCWSTR(encoded.as_ptr())
     }
@@ -42,17 +39,15 @@ impl IntoPCWSTR for &str {
 #[cfg(windows)]
 impl IntoPWSTR for &str {
     fn into_pwstr(self) -> PWSTR {
-        let mut encoded = self
-            .encode_utf16()
-            .chain([0u16])
-            .collect::<Vec<u16>>();
+        let mut encoded = self.encode_utf16().chain([0u16]).collect::<Vec<u16>>();
 
-        PWSTR(encoded.as_mut_ptr())    }
+        PWSTR(encoded.as_mut_ptr())
+    }
 }
 
 #[cfg(windows)]
 impl IntoPSTR for &str {
-     fn into_pstr(self) -> PSTR {
+    fn into_pstr(self) -> PSTR {
         let mut encoded = self
             .as_bytes()
             .iter()
@@ -60,29 +55,28 @@ impl IntoPSTR for &str {
             .chain([0u8])
             .collect::<Vec<u8>>();
 
-        PSTR(encoded.as_mut_ptr())    }
+        PSTR(encoded.as_mut_ptr())
+    }
 }
 
 #[cfg(windows)]
 impl IntoPCSTR for &str {
     fn into_pcstr(self) -> PCSTR {
-       let encoded = self
-           .as_bytes()
-           .iter()
-           .cloned()
-           .chain([0u8])
-           .collect::<Vec<u8>>();
+        let encoded = self
+            .as_bytes()
+            .iter()
+            .cloned()
+            .chain([0u8])
+            .collect::<Vec<u8>>();
 
-       PCSTR(encoded.as_ptr())    }
+        PCSTR(encoded.as_ptr())
+    }
 }
 
 #[cfg(windows)]
 impl IntoPWSTR for String {
     fn into_pwstr(self) -> PWSTR {
-        let mut encoded = self
-            .encode_utf16()
-            .chain([0u16])
-            .collect::<Vec<u16>>();
+        let mut encoded = self.encode_utf16().chain([0u16]).collect::<Vec<u16>>();
 
         PWSTR(encoded.as_mut_ptr())
     }
@@ -147,7 +141,7 @@ fn main() {
         let kernel32_res = unsafe { GetModuleHandleW(&HSTRING::from("kernel32.dll")) };
         let kernel32 = kernel32_res.unwrap();
 
-        let conpty = unsafe { GetProcAddress(kernel32,  "CreatePseudoConsole".into_pcstr()) };
+        let conpty = unsafe { GetProcAddress(kernel32, "CreatePseudoConsole".into_pcstr()) };
         match conpty {
             Some(_) => {
                 conpty_enabled = "1";

--- a/src/examples/conpty.rs
+++ b/src/examples/conpty.rs
@@ -1,6 +1,6 @@
 extern crate winptyrs;
 use std::ffi::OsString;
-use winptyrs::{PTY, PTYArgs, PTYBackend, AgentConfig, MouseMode};
+use winptyrs::{AgentConfig, MouseMode, PTYArgs, PTYBackend, PTY};
 
 fn main() {
     let pty_args = PTYArgs {
@@ -8,7 +8,7 @@ fn main() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     match PTY::new_with_backend(&pty_args, PTYBackend::ConPTY) {
@@ -21,60 +21,62 @@ fn main() {
                     let mut output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     match pty.write(OsString::from("echo \"aaaa 😀\"")) {
                         Ok(bytes) => println!("Bytes written: {}", bytes),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     match pty.is_alive() {
                         Ok(alive) => println!("Is alive {}", alive),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     match pty.write(OsString::from("\r\n")) {
                         Ok(bytes) => println!("Bytes written: {}", bytes),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
-                },
+                }
                 Err(err) => {
                     println!("{:?}", err);
                     panic!("{:?}", err)
                 }
             }
-        },
-        Err(err) => {panic!("{:?}", err)}
+        }
+        Err(err) => {
+            panic!("{:?}", err)
+        }
     }
 }

--- a/src/examples/winpty.rs
+++ b/src/examples/winpty.rs
@@ -1,6 +1,6 @@
 extern crate winptyrs;
 use std::ffi::OsString;
-use winptyrs::{PTY, PTYArgs, PTYBackend, AgentConfig, MouseMode};
+use winptyrs::{AgentConfig, MouseMode, PTYArgs, PTYBackend, PTY};
 
 fn main() {
     let pty_args = PTYArgs {
@@ -8,7 +8,7 @@ fn main() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     match PTY::new_with_backend(&pty_args, PTYBackend::WinPTY) {
@@ -21,60 +21,62 @@ fn main() {
                     let mut output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{:?}", out),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{:?}", out),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     match pty.write(OsString::from("echo \"aaaa 😀\"")) {
                         Ok(bytes) => println!("Bytes written: {}", bytes),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{:?}", out),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{:?}", out),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     match pty.is_alive() {
                         Ok(alive) => println!("Is alive {}", alive),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     match pty.write(OsString::from("\r\n")) {
                         Ok(bytes) => println!("Bytes written: {}", bytes),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{:?}", out),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
 
                     output = pty.read(1000, false);
                     match output {
                         Ok(out) => println!("{:?}", out),
-                        Err(err) => panic!("{:?}", err)
+                        Err(err) => panic!("{:?}", err),
                     }
-                },
+                }
                 Err(err) => {
                     println!("{:?}", err);
                     panic!("{:?}", err)
                 }
             }
-        },
-        Err(err) => {panic!("{:?}", err)}
+        }
+        Err(err) => {
+            panic!("{:?}", err)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,10 @@
 //! [`WinPTY`]: https://github.com/rprichard/winpty
 //! [`ConPTY`]: https://docs.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session
 
-
 #[macro_use]
 extern crate enum_primitive_derive;
 extern crate num_traits;
 
 pub mod pty;
 // mod pty_spawn;
-pub use pty::{PTY, PTYArgs, PTYBackend, MouseMode, AgentConfig};
+pub use pty::{AgentConfig, MouseMode, PTYArgs, PTYBackend, PTY};

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -117,6 +117,7 @@ pub struct PTYArgs {
 /// let conpty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
 /// let winpty = PTY::new_with_backend(&pty_args, PTYBackend::WinPTY).unwrap();
 /// ```
+#[derive(Clone)]
 pub struct PTY {
     /// Backend used by the current pseudoterminal, must be one of [`self::PTYBackend`].
     /// If the value is [`self::PTYBackend::NoBackend`], then no operations will be available.

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -1,4 +1,3 @@
-
 //! This module declares the [`PTY`] struct, which enables a Rust
 //! program to create a pseudoterminal (PTY) in Windows.
 //!
@@ -10,49 +9,49 @@
 // External imports
 
 // Local modules
-mod winpty;
-mod conpty;
 mod base;
+mod conpty;
+mod winpty;
 
+use parking_lot::Mutex;
 use std::ffi::OsString;
+use std::sync::Arc;
 
 // Local imports
-use self::winpty::WinPTY;
-pub use self::winpty::{MouseMode, AgentConfig};
 use self::conpty::ConPTY;
+use self::winpty::WinPTY;
+pub use self::winpty::{AgentConfig, MouseMode};
 pub use base::{PTYImpl, PTYProcess};
 
 /// Available backends to create pseudoterminals.
-#[derive(Primitive)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Primitive, Copy, Clone, Debug)]
 pub enum PTYBackend {
-	/// Use the native Windows API, available from Windows 10 (Build version 1809).
-	ConPTY = 0,
-	/// Use the [winpty](https://github.com/rprichard/winpty) library, useful in older Windows systems.
-	WinPTY = 1,
+    /// Use the native Windows API, available from Windows 10 (Build version 1809).
+    ConPTY = 0,
+    /// Use the [winpty](https://github.com/rprichard/winpty) library, useful in older Windows systems.
+    WinPTY = 1,
     /// Placeholder value used to select the PTY backend automatically
-	Auto = 2,
-	/// Placeholder value used to declare that a PTY was created with no backend.
-	NoBackend = 3,
+    Auto = 2,
+    /// Placeholder value used to declare that a PTY was created with no backend.
+    NoBackend = 3,
 }
 
 /// Data struct that represents the possible arguments used to create a pseudoterminal
 pub struct PTYArgs {
-	// Common arguments
-	/// Number of character columns to display.
-	pub cols: i32,
-	/// Number of line rows to display
-	pub rows: i32,
-	// WinPTY backend-specific arguments
-	/// Mouse capture settings for the winpty backend.
-	pub mouse_mode: MouseMode,
-	/// Amount of time to wait for the agent (in ms) to startup and to wait for any given
+    // Common arguments
+    /// Number of character columns to display.
+    pub cols: i32,
+    /// Number of line rows to display
+    pub rows: i32,
+    // WinPTY backend-specific arguments
+    /// Mouse capture settings for the winpty backend.
+    pub mouse_mode: MouseMode,
+    /// Amount of time to wait for the agent (in ms) to startup and to wait for any given
     /// agent RPC request.
-	pub timeout: u32,
-	/// General configuration settings for the winpty backend.
-	pub agent_config: AgentConfig
+    pub timeout: u32,
+    /// General configuration settings for the winpty backend.
+    pub agent_config: AgentConfig,
 }
-
 
 /// Pseudoterminal struct that communicates with a spawned process.
 ///
@@ -119,118 +118,120 @@ pub struct PTYArgs {
 /// let winpty = PTY::new_with_backend(&pty_args, PTYBackend::WinPTY).unwrap();
 /// ```
 pub struct PTY {
-	 /// Backend used by the current pseudoterminal, must be one of [`self::PTYBackend`].
-	 /// If the value is [`self::PTYBackend::NoBackend`], then no operations will be available.
-	 backend: PTYBackend,
-	 /// Reference to the PTY handler which depends on the value of `backend`.
-	 pty: Box<dyn PTYImpl>
+    /// Backend used by the current pseudoterminal, must be one of [`self::PTYBackend`].
+    /// If the value is [`self::PTYBackend::NoBackend`], then no operations will be available.
+    backend: PTYBackend,
+    /// Reference to the PTY handler which depends on the value of `backend`.
+    pty: Arc<Mutex<dyn PTYImpl>>,
 }
 
 impl PTY {
-	/// Create a new pseudoterminal setting the backend automatically.
-	pub fn new(args: &PTYArgs) -> Result<PTY, OsString> {
-		let mut errors: OsString = OsString::from("There were some errors trying to instantiate a PTY:");
-		// Try to create a PTY using the ConPTY backend
-		let conpty_instance: Result<Box<dyn PTYImpl>, OsString> = ConPTY::new(args);
-	 	let pty: Option<PTY> =
-			match conpty_instance {
-				Ok(conpty) => {
-					let pty_instance = PTY {
-						backend: PTYBackend::ConPTY,
-						pty: conpty
-					};
-					Some(pty_instance)
-				},
-				Err(err) => {
-					errors = OsString::from(format!("{:?} (ConPTY) -> {:?};", errors, err));
-					None
-				}
-			};
+    /// Create a new pseudoterminal setting the backend automatically.
+    pub fn new(args: &PTYArgs) -> Result<PTY, OsString> {
+        let mut errors: OsString =
+            OsString::from("There were some errors trying to instantiate a PTY:");
+        // Try to create a PTY using the ConPTY backend
+        let conpty_instance: Result<Arc<Mutex<dyn PTYImpl>>, OsString> = ConPTY::new(args);
+        let pty: Option<PTY> = match conpty_instance {
+            Ok(conpty) => {
+                let pty_instance = PTY {
+                    backend: PTYBackend::ConPTY,
+                    pty: conpty,
+                };
+                Some(pty_instance)
+            }
+            Err(err) => {
+                errors = OsString::from(format!("{:?} (ConPTY) -> {:?};", errors, err));
+                None
+            }
+        };
 
-		// Try to create a PTY instance using the WinPTY backend
-		match pty {
-			Some(pty) => Ok(pty),
-			None => {
-				let winpty_instance: Result<Box<dyn PTYImpl>, OsString> = WinPTY::new(args);
-				match winpty_instance {
-					Ok(winpty) => {
-						let pty_instance = PTY {
-							backend: PTYBackend::WinPTY,
-							pty: winpty
-						};
-						Ok(pty_instance)
-					},
-					Err(err) => {
-						errors = OsString::from(format!("{:?} (WinPTY) -> {:?}", errors, err));
-						Err(errors)
-					}
-				}
-			}
-		}
-	}
+        // Try to create a PTY instance using the WinPTY backend
+        match pty {
+            Some(pty) => Ok(pty),
+            None => {
+                let winpty_instance: Result<Arc<Mutex<dyn PTYImpl>>, OsString> = WinPTY::new(args);
+                match winpty_instance {
+                    Ok(winpty) => {
+                        let pty_instance = PTY {
+                            backend: PTYBackend::WinPTY,
+                            pty: winpty,
+                        };
+                        Ok(pty_instance)
+                    }
+                    Err(err) => {
+                        errors = OsString::from(format!("{:?} (WinPTY) -> {:?}", errors, err));
+                        Err(errors)
+                    }
+                }
+            }
+        }
+    }
 
-	/// Create a new pseudoterminal using a given backend
-	pub fn new_with_backend(args: &PTYArgs, backend: PTYBackend) -> Result<PTY, OsString> {
-		match backend {
-			PTYBackend::ConPTY => {
-				match ConPTY::new(args) {
-					Ok(conpty) => {
-						let pty = PTY {
-							backend,
-							pty: conpty
-						};
-						Ok(pty)
-					},
-					Err(err) => Err(err)
-				}
-			},
-			PTYBackend::WinPTY => {
-				match WinPTY::new(args) {
-					Ok(winpty) => {
-						let pty = PTY {
-							backend,
-							pty: winpty
-						};
-						Ok(pty)
-					},
-					Err(err) => Err(err)
-				}
-			},
-			PTYBackend::Auto => PTY::new(args),
-			PTYBackend::NoBackend => Err(OsString::from("NoBackend is not a valid option"))
-		}
-	}
+    /// Create a new pseudoterminal using a given backend
+    pub fn new_with_backend(args: &PTYArgs, backend: PTYBackend) -> Result<PTY, OsString> {
+        match backend {
+            PTYBackend::ConPTY => match ConPTY::new(args) {
+                Ok(conpty) => {
+                    let pty = PTY {
+                        backend,
+                        pty: conpty,
+                    };
+                    Ok(pty)
+                }
+                Err(err) => Err(err),
+            },
+            PTYBackend::WinPTY => match WinPTY::new(args) {
+                Ok(winpty) => {
+                    let pty = PTY {
+                        backend,
+                        pty: winpty,
+                    };
+                    Ok(pty)
+                }
+                Err(err) => Err(err),
+            },
+            PTYBackend::Auto => PTY::new(args),
+            PTYBackend::NoBackend => Err(OsString::from("NoBackend is not a valid option")),
+        }
+    }
 
-	/// Spawn a process inside the PTY.
-	///
-	/// # Arguments
-	/// * `appname` - Full path to the executable binary to spawn.
-	/// * `cmdline` - Optional space-delimited arguments to provide to the executable.
-	/// * `cwd` - Optional path from where the executable should be spawned.
-	/// * `env` - Optional environment variables to provide to the process. Each
-	/// variable should be declared as `VAR=VALUE` and be separated by a NUL (0) character.
-	///
-	/// # Returns
-	/// `true` if the call was successful, else an error will be returned.
-	pub fn spawn(&mut self, appname: OsString, cmdline: Option<OsString>, cwd: Option<OsString>, env: Option<OsString>) -> Result<bool, OsString> {
-		self.pty.spawn(appname, cmdline, cwd, env)
-	}
+    /// Spawn a process inside the PTY.
+    ///
+    /// # Arguments
+    /// * `appname` - Full path to the executable binary to spawn.
+    /// * `cmdline` - Optional space-delimited arguments to provide to the executable.
+    /// * `cwd` - Optional path from where the executable should be spawned.
+    /// * `env` - Optional environment variables to provide to the process. Each
+    /// variable should be declared as `VAR=VALUE` and be separated by a NUL (0) character.
+    ///
+    /// # Returns
+    /// `true` if the call was successful, else an error will be returned.
+    pub fn spawn(
+        &self,
+        appname: OsString,
+        cmdline: Option<OsString>,
+        cwd: Option<OsString>,
+        env: Option<OsString>,
+    ) -> Result<bool, OsString> {
+        self.pty.lock().spawn(appname, cmdline, cwd, env)
+    }
 
-	/// Change the PTY size.
+    /// Change the PTY size.
     ///
     /// # Arguments
     /// * `cols` - Number of character columns to display.
     /// * `rows` - Number of line rows to display.
-	pub fn set_size(&self, cols: i32, rows: i32) -> Result<(), OsString> {
-		self.pty.set_size(cols, rows)
-	}
+    pub fn set_size(&self, cols: i32, rows: i32) -> Result<(), OsString> {
+        self.pty.lock().set_size(cols, rows)
+    }
 
-	/// Get the backend used by the current PTY.
-	pub fn get_backend(&self) -> PTYBackend {
-		self.backend
-	}
+    /// Get the backend used by the current PTY.
+    pub fn get_backend(&self) -> PTYBackend {
+        self.backend
+    }
 
-	/// Read at most `length` characters from a process standard output.
+    /// Read at most `length` characters from a process standard output.
     ///
     /// # Arguments
     /// * `length` - Upper limit on the number of characters to read.
@@ -243,11 +244,11 @@ impl PTY {
     ///
     /// * The bytes returned are represented using a [`OsString`] since Windows operates over
     /// `u16` strings.
-	pub fn read(&self, length: u32, blocking: bool) -> Result<OsString, OsString> {
-        self.pty.read(length, blocking)
+    pub fn read(&self, length: u32, blocking: bool) -> Result<OsString, OsString> {
+        self.pty.lock().read(length, blocking)
     }
 
-	/// Write a (possibly) UTF-16 string into the standard input of a process.
+    /// Write a (possibly) UTF-16 string into the standard input of a process.
     ///
     /// # Arguments
     /// * `buf` - [`OsString`] containing the string to write.
@@ -256,43 +257,43 @@ impl PTY {
     /// The total number of characters written if the call was successful, else
     /// an [`OsString`] containing an human-readable error.
     pub fn write(&self, buf: OsString) -> Result<u32, OsString> {
-        self.pty.write(buf)
+        self.pty.lock().write(buf)
     }
 
-	/// Check if a process reached End-of-File (EOF).
+    /// Check if a process reached End-of-File (EOF).
     ///
     /// # Returns
     /// `true` if the process reached EOL, false otherwise. If an error occurs, then a [`OsString`]
     /// containing a human-readable error is raised.
     pub fn is_eof(&self) -> Result<bool, OsString> {
-		self.pty.is_eof()
+        self.pty.lock().is_eof()
     }
 
-	/// Retrieve the exit status of the process.
+    /// Retrieve the exit status of the process.
     ///
     /// # Returns
     /// `None` if the process has not exited, else the exit code of the process.
     pub fn get_exitstatus(&self) -> Result<Option<u32>, OsString> {
-        self.pty.get_exitstatus()
+        self.pty.lock().get_exitstatus()
     }
 
-	/// Determine if the process is still alive.
+    /// Determine if the process is still alive.
     pub fn is_alive(&self) -> Result<bool, OsString> {
-        self.pty.is_alive()
+        self.pty.lock().is_alive()
     }
 
-	/// Retrieve the process ID (PID) of the spawned program.
-	pub fn get_pid(&self) -> u32 {
-        self.pty.get_pid()
+    /// Retrieve the process ID (PID) of the spawned program.
+    pub fn get_pid(&self) -> u32 {
+        self.pty.lock().get_pid()
     }
 
-	/// Retrieve the process handle ID of the spawned program.
-	pub fn get_fd(&self) -> isize {
-		self.pty.get_fd()
-	}
+    /// Retrieve the process handle ID of the spawned program.
+    pub fn get_fd(&self) -> isize {
+        self.pty.lock().get_fd()
+    }
 
-	/// Wait for the process to exit/finish.
+    /// Wait for the process to exit/finish.
     pub fn wait_for_exit(&self) -> Result<bool, OsString> {
-		self.pty.wait_for_exit()
-	}
+        self.pty.lock().wait_for_exit()
+    }
 }

--- a/src/pty/base.rs
+++ b/src/pty/base.rs
@@ -1,27 +1,32 @@
+use windows::core::{Error, HRESULT, PCSTR};
 /// Base struct used to generalize some of the PTY I/O operations.
-
-use windows::Win32::Foundation::{CloseHandle, HANDLE, STATUS_PENDING, S_OK, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::Foundation::{
+    CloseHandle, HANDLE, STATUS_PENDING, S_OK, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
+use windows::Win32::Globalization::{
+    MultiByteToWideChar, WideCharToMultiByte, CP_UTF8, MULTI_BYTE_TO_WIDE_CHAR_FLAGS,
+};
 use windows::Win32::Storage::FileSystem::{GetFileSizeEx, ReadFile, WriteFile};
 use windows::Win32::System::Pipes::PeekNamedPipe;
-use windows::Win32::System::IO::CancelIoEx;
-use windows::Win32::System::Threading::{GetExitCodeProcess, GetProcessId, WaitForSingleObject};
-use windows::Win32::Globalization::{MultiByteToWideChar, WideCharToMultiByte, CP_UTF8, MULTI_BYTE_TO_WIDE_CHAR_FLAGS};
-use windows::core::{HRESULT, Error, PCSTR};
 use windows::Win32::System::Threading::INFINITE;
+use windows::Win32::System::Threading::{GetExitCodeProcess, GetProcessId, WaitForSingleObject};
+use windows::Win32::System::IO::CancelIoEx;
 
-use std::ptr;
-use std::sync::mpsc;
-use std::thread;
-use std::time::Duration;
-use std::mem::MaybeUninit;
+use core::ffi::c_void;
+use parking_lot::Mutex;
 use std::cmp::min;
 use std::ffi::OsString;
-use core::ffi::c_void;
+use std::mem::MaybeUninit;
+use std::ptr;
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 #[cfg(windows)]
-use std::os::windows::prelude::*;
-#[cfg(windows)]
 use std::os::windows::ffi::OsStrExt;
+#[cfg(windows)]
+use std::os::windows::prelude::*;
 #[cfg(unix)]
 use std::vec::IntoIter;
 
@@ -31,7 +36,6 @@ use super::PTYArgs;
 trait OsStrExt {
     fn from_wide(x: &[u16]) -> OsString;
     fn encode_wide(&self) -> IntoIter<u16>;
-
 }
 
 #[cfg(unix)]
@@ -45,7 +49,6 @@ impl OsStrExt for OsString {
     }
 }
 
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LocalHandle(pub *mut c_void);
 
@@ -57,7 +60,6 @@ impl LocalHandle {
 
 unsafe impl Send for LocalHandle {}
 unsafe impl Sync for LocalHandle {}
-
 
 impl From<HANDLE> for LocalHandle {
     fn from(value: HANDLE) -> Self {
@@ -71,7 +73,6 @@ impl From<LocalHandle> for HANDLE {
     }
 }
 
-
 /// This trait should be implemented by any backend that wants to provide a PTY implementation.
 pub trait PTYImpl: Sync + Send {
     /// Create a new instance of the PTY backend.
@@ -82,21 +83,28 @@ pub trait PTYImpl: Sync + Send {
     /// # Returns
     /// * `pty`: The instantiated PTY struct.
     #[allow(clippy::new_ret_no_self)]
-    fn new(args: &PTYArgs) -> Result<Box<dyn PTYImpl>, OsString>
-        where Self: Sized;
+    fn new(args: &PTYArgs) -> Result<Arc<Mutex<dyn PTYImpl>>, OsString>
+    where
+        Self: Sized;
 
     /// Spawn a process inside the PTY.
-	///
-	/// # Arguments
-	/// * `appname` - Full path to the executable binary to spawn.
-	/// * `cmdline` - Optional space-delimited arguments to provide to the executable.
-	/// * `cwd` - Optional path from where the executable should be spawned.
-	/// * `env` - Optional environment variables to provide to the process. Each
-	/// variable should be declared as `VAR=VALUE` and be separated by a NUL (0) character.
-	///
-	/// # Returns
-	/// `true` if the call was successful, else an error will be returned.
-    fn spawn(&mut self, appname: OsString, cmdline: Option<OsString>, cwd: Option<OsString>, env: Option<OsString>) -> Result<bool, OsString>;
+    ///
+    /// # Arguments
+    /// * `appname` - Full path to the executable binary to spawn.
+    /// * `cmdline` - Optional space-delimited arguments to provide to the executable.
+    /// * `cwd` - Optional path from where the executable should be spawned.
+    /// * `env` - Optional environment variables to provide to the process. Each
+    /// variable should be declared as `VAR=VALUE` and be separated by a NUL (0) character.
+    ///
+    /// # Returns
+    /// `true` if the call was successful, else an error will be returned.
+    fn spawn(
+        &mut self,
+        appname: OsString,
+        cmdline: Option<OsString>,
+        cwd: Option<OsString>,
+        env: Option<OsString>,
+    ) -> Result<bool, OsString>;
 
     /// Change the PTY size.
     ///
@@ -150,14 +158,18 @@ pub trait PTYImpl: Sync + Send {
     fn get_pid(&self) -> u32;
 
     /// Retrieve the process handle ID of the spawned program.
-	fn get_fd(&self) -> isize;
+    fn get_fd(&self) -> isize;
 
     /// Wait for the process to exit/finish.
     fn wait_for_exit(&self) -> Result<bool, OsString>;
 }
 
-
-fn read(mut length: u32, blocking: bool, stream: HANDLE, using_pipes: bool) -> Result<OsString, OsString> {
+fn read(
+    mut length: u32,
+    blocking: bool,
+    stream: HANDLE,
+    using_pipes: bool,
+) -> Result<OsString, OsString> {
     let mut result: HRESULT;
     if !blocking {
         if using_pipes {
@@ -169,15 +181,11 @@ fn read(mut length: u32, blocking: bool, stream: HANDLE, using_pipes: bool) -> R
                 let bytes_ptr = ptr::addr_of_mut!(*bytes_u.as_mut_ptr());
                 let bytes_ref = bytes_ptr.as_mut().unwrap();
 
-                result =
-                    if PeekNamedPipe(stream, None,
-                                     0, Some(bytes_ref),
-                                     None, None).is_ok() {
-                        S_OK
-                    } else {
-                        Error::from_win32().into()
-                    };
-
+                result = if PeekNamedPipe(stream, None, 0, Some(bytes_ref), None, None).is_ok() {
+                    S_OK
+                } else {
+                    Error::from_win32().into()
+                };
 
                 if result.is_err() {
                     let result_msg = result.message();
@@ -196,7 +204,11 @@ fn read(mut length: u32, blocking: bool, stream: HANDLE, using_pipes: bool) -> R
                 let size_ptr = ptr::addr_of_mut!(*size.as_mut_ptr());
                 let size_ref = size_ptr.as_mut().unwrap();
                 // let size_ref = *size.as_mut_ptr();
-                result = if GetFileSizeEx(stream, size_ref).is_ok() { S_OK } else { Error::from_win32().into() };
+                result = if GetFileSizeEx(stream, size_ref).is_ok() {
+                    S_OK
+                } else {
+                    Error::from_win32().into()
+                };
 
                 if result.is_err() {
                     let result_msg = result.message();
@@ -217,34 +229,30 @@ fn read(mut length: u32, blocking: bool, stream: HANDLE, using_pipes: bool) -> R
     //let chars_read: *mut u32 = ptr::null_mut();
     // println!("Length: {}, {}", length, length > 0);
     // if length > 0 {
-        unsafe {
-            match length {
-                0 => {
+    unsafe {
+        match length {
+            0 => {}
+            _ => {
+                // let chars_read_ptr = chars_read.as_mut_ptr();
+                let chars_read_ptr = ptr::addr_of_mut!(*chars_read.as_mut_ptr());
+                // let chars_read_mut = chars_read_ptr.as_mut();
+                let chars_read_mut = Some(chars_read_ptr);
+                // println!("Blocked here");
+                result = if ReadFile(stream, Some(&mut buf_vec[..]), chars_read_mut, None).is_ok() {
+                    S_OK
+                } else {
+                    Error::from_win32().into()
+                };
+                // println!("Unblocked here");
 
-                }
-                _ => {
-                    // let chars_read_ptr = chars_read.as_mut_ptr();
-                    let chars_read_ptr = ptr::addr_of_mut!(*chars_read.as_mut_ptr());
-                    // let chars_read_mut = chars_read_ptr.as_mut();
-                    let chars_read_mut = Some(chars_read_ptr);
-                    // println!("Blocked here");
-                    result =
-                        if ReadFile(stream, Some(&mut buf_vec[..]),
-                                    chars_read_mut, None).is_ok() {
-                            S_OK
-                        } else {
-                            Error::from_win32().into()
-                        };
-                    // println!("Unblocked here");
-
-                    if result.is_err() {
-                        let result_msg = result.message();
-                        let string = OsString::from(result_msg);
-                        return Err(string);
-                    }
+                if result.is_err() {
+                    let result_msg = result.message();
+                    let string = OsString::from(result_msg);
+                    return Err(string);
                 }
             }
         }
+    }
     // }
 
     // let os_str = OsString::with_capacity(buf_vec.len());
@@ -252,20 +260,23 @@ fn read(mut length: u32, blocking: bool, stream: HANDLE, using_pipes: bool) -> R
 
     unsafe {
         MultiByteToWideChar(
-            CP_UTF8, MULTI_BYTE_TO_WIDE_CHAR_FLAGS(0), &buf_vec[..],
-            Some(&mut vec_buf[..]));
+            CP_UTF8,
+            MULTI_BYTE_TO_WIDE_CHAR_FLAGS(0),
+            &buf_vec[..],
+            Some(&mut vec_buf[..]),
+        );
     }
 
     // let non_zeros: Vec<u16> = vec_buf.split(|elem| *elem == 0 as u16).collect();
     let non_zeros_init = Vec::new();
     let non_zeros: Vec<u16> =
         vec_buf
-        .split(|x| x == &0)
-        .map(|x| x.to_vec())
-        .fold(non_zeros_init, |mut acc, mut x| {
-            acc.append(&mut x);
-            acc
-        });
+            .split(|x| x == &0)
+            .map(|x| x.to_vec())
+            .fold(non_zeros_init, |mut acc, mut x| {
+                acc.append(&mut x);
+                acc
+            });
     // let non_zeros: &[u16] = non_zeros_slices.into_iter().reduce(|acc, item| [acc, item].concat()).unwrap();
     let os_str = OsString::from_wide(&non_zeros[..]);
     Ok(os_str)
@@ -304,7 +315,6 @@ fn wait_for_exit(process: HANDLE) -> Result<bool, OsString> {
     }
 }
 
-
 fn get_exitstatus(process: HANDLE) -> Result<Option<u32>, OsString> {
     let mut exit = MaybeUninit::<u32>::uninit();
     unsafe {
@@ -335,8 +345,7 @@ fn is_eof(process: HANDLE, stream: HANDLE) -> Result<bool, OsString> {
     unsafe {
         let bytes_ptr: *mut u32 = ptr::addr_of_mut!(*bytes.as_mut_ptr());
         let bytes_ref = Some(bytes_ptr);
-        let succ = PeekNamedPipe(
-            stream, None, 0, None, bytes_ref, None).is_ok();
+        let succ = PeekNamedPipe(stream, None, 0, None, bytes_ref, None).is_ok();
 
         let total_bytes = bytes.assume_init();
         if succ {
@@ -344,8 +353,8 @@ fn is_eof(process: HANDLE, stream: HANDLE) -> Result<bool, OsString> {
                 Ok(alive) => {
                     let eof = !alive && total_bytes == 0;
                     Ok(eof)
-                },
-                Err(_) => Ok(true)
+                }
+                Err(_) => Ok(true),
             }
         } else {
             Ok(true)
@@ -409,7 +418,10 @@ impl PTYProcess {
                 // let mut alive = reader_alive_rx.recv_timeout(Duration::from_millis(300)).unwrap_or(true);
                 // alive = alive && !is_eof(process, conout).unwrap();
 
-                while reader_alive_rx.recv_timeout(Duration::from_millis(100)).unwrap_or(true) {
+                while reader_alive_rx
+                    .recv_timeout(Duration::from_millis(100))
+                    .unwrap_or(true)
+                {
                     if !is_eof(process.into(), conout.into()).unwrap() {
                         let result = read(4096, true, conout.into(), using_pipes);
                         reader_out_tx.send(Some(result)).unwrap();
@@ -439,34 +451,27 @@ impl PTYProcess {
 
                     eof_reached = false;
 
-                    let out =
-                        match pending_read {
-                            Some(bytes) => Ok(bytes),
-                            None => {
-                                match blocking {
-                                    true => {
-                                        match reader_out_rx.recv() {
-                                            Ok(None) => {
-                                                eof_reached = true;
-                                                Ok(OsString::new())
-                                            }
-                                            Ok(Some(bytes)) => bytes,
-                                            Err(_) => Ok(OsString::new())
-                                        }
-                                    },
-                                    false => {
-                                        match reader_out_rx.recv_timeout(Duration::from_millis(200)) {
-                                            Ok(None) => {
-                                                eof_reached = true;
-                                                Ok(OsString::new())
-                                            }
-                                            Ok(Some(bytes)) => bytes,
-                                            Err(_) => Ok(OsString::new())
-                                        }
-                                    }
+                    let out = match pending_read {
+                        Some(bytes) => Ok(bytes),
+                        None => match blocking {
+                            true => match reader_out_rx.recv() {
+                                Ok(None) => {
+                                    eof_reached = true;
+                                    Ok(OsString::new())
                                 }
-                            }
-                        };
+                                Ok(Some(bytes)) => bytes,
+                                Err(_) => Ok(OsString::new()),
+                            },
+                            false => match reader_out_rx.recv_timeout(Duration::from_millis(200)) {
+                                Ok(None) => {
+                                    eof_reached = true;
+                                    Ok(OsString::new())
+                                }
+                                Ok(Some(bytes)) => bytes,
+                                Err(_) => Ok(OsString::new()),
+                            },
+                        },
+                    };
 
                     match out {
                         Ok(bytes) => {
@@ -477,12 +482,16 @@ impl PTYProcess {
                             let to_return = OsString::from_wide(left);
                             read_buf = OsString::from_wide(right);
                             if eof_reached && to_return.is_empty() && length != 0 {
-                                cache_resp_tx.send(Err(OsString::from("Standard out reached EOF"))).unwrap();
+                                cache_resp_tx
+                                    .send(Err(OsString::from("Standard out reached EOF")))
+                                    .unwrap();
                             } else {
                                 cache_resp_tx.send(Ok(to_return)).unwrap();
                             }
-                        },
-                        Err(err) => { cache_resp_tx.send(Err(err)).unwrap(); }
+                        }
+                        Err(err) => {
+                            cache_resp_tx.send(Err(err)).unwrap();
+                        }
                     }
                 }
             }
@@ -528,7 +537,7 @@ impl PTYProcess {
         match self.cache_resp.recv() {
             Ok(Ok(bytes)) => Ok(bytes),
             Ok(Err(err)) => Err(err),
-            Err(err) => Err(err.to_string().into())
+            Err(err) => Err(err.to_string().into()),
         }
         // let out = self.reader_in.recv().unwrap();
         // out
@@ -548,27 +557,44 @@ impl PTYProcess {
 
         unsafe {
             let required_size = WideCharToMultiByte(
-                CP_UTF8, 0, &vec_buf[..], None,
-                PCSTR(ptr::null_mut::<u8>()), None);
+                CP_UTF8,
+                0,
+                &vec_buf[..],
+                None,
+                PCSTR(ptr::null_mut::<u8>()),
+                None,
+            );
 
-            let mut bytes_buf: Vec<u8> = std::iter::repeat(0).take((required_size) as usize).collect();
+            let mut bytes_buf: Vec<u8> = std::iter::repeat(0)
+                .take((required_size) as usize)
+                .collect();
 
             WideCharToMultiByte(
-                CP_UTF8, 0, &vec_buf[..], Some(&mut bytes_buf[..]),
+                CP_UTF8,
+                0,
+                &vec_buf[..],
+                Some(&mut bytes_buf[..]),
                 PCSTR(ptr::null_mut::<u8>()),
-                None);
+                None,
+            );
 
             let mut written_bytes = MaybeUninit::<u32>::uninit();
             let bytes_ptr: *mut u32 = ptr::addr_of_mut!(*written_bytes.as_mut_ptr());
             let bytes_ref = Some(bytes_ptr);
             // let bytes_ref = bytes_ptr.as_mut();
 
-            result =
-                if WriteFile(Into::<HANDLE>::into(self.conin), Some(&bytes_buf[..]), bytes_ref, None).is_ok() {
-                    S_OK
-                } else {
-                    Error::from_win32().into()
-                };
+            result = if WriteFile(
+                Into::<HANDLE>::into(self.conin),
+                Some(&bytes_buf[..]),
+                bytes_ref,
+                None,
+            )
+            .is_ok()
+            {
+                S_OK
+            } else {
+                Error::from_win32().into()
+            };
 
             if result.is_err() {
                 let result_msg = result.message();
@@ -594,18 +620,24 @@ impl PTYProcess {
             let bytes_ptr: *mut u32 = ptr::addr_of_mut!(*bytes.as_mut_ptr());
             let bytes_ref = Some(bytes_ptr);
             let mut succ = PeekNamedPipe(
-                Into::<HANDLE>::into(self.conout), None, 0, bytes_ref, None, None).is_ok();
+                Into::<HANDLE>::into(self.conout),
+                None,
+                0,
+                bytes_ref,
+                None,
+                None,
+            )
+            .is_ok();
 
             let total_bytes = bytes.assume_init();
 
             if succ {
-                let is_alive =
-                    match self.is_alive() {
-                        Ok(alive) => alive,
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    };
+                let is_alive = match self.is_alive() {
+                    Ok(alive) => alive,
+                    Err(err) => {
+                        return Err(err);
+                    }
+                };
 
                 if total_bytes == 0 && !is_alive {
                     succ = false;
@@ -614,7 +646,6 @@ impl PTYProcess {
 
             Ok(!succ)
         }
-
     }
 
     /// Retrieve the exit status of the process
@@ -628,7 +659,7 @@ impl PTYProcess {
 
         match get_exitstatus(self.process.into()) {
             Ok(exitstatus) => Ok(exitstatus),
-            Err(err) => Err(err)
+            Err(err) => Err(err),
         }
     }
 
@@ -637,10 +668,8 @@ impl PTYProcess {
         // let mut exit_code: Box<u32> = Box::new_uninit();
         // let exit_ptr: *mut u32 = &mut *exit_code;
         match is_alive(self.process.into()) {
-            Ok(alive) => {
-                Ok(alive)
-            },
-            Err(err) => Err(err)
+            Ok(alive) => Ok(alive),
+            Err(err) => Err(err),
         }
     }
 
@@ -672,7 +701,7 @@ impl PTYProcess {
     }
 
     /// Retrieve the process handle ID of the spawned program.
-	pub fn get_fd(&self) -> isize {
+    pub fn get_fd(&self) -> isize {
         self.process.0 as isize
     }
 
@@ -680,20 +709,19 @@ impl PTYProcess {
     pub fn wait_for_exit(&self) -> Result<bool, OsString> {
         wait_for_exit(self.process.into())
     }
-
 }
 
 impl Drop for PTYProcess {
     fn drop(&mut self) {
         unsafe {
             // Unblock thread if it is waiting for a process handle.
-            if self.reader_process_out.send(None).is_ok() { }
+            if self.reader_process_out.send(None).is_ok() {}
 
             // Cancel all pending IO operations on conout
             let _ = CancelIoEx(Into::<HANDLE>::into(self.conout), None);
 
             // Send instruction to thread to finish
-            if self.reader_alive.send(false).is_ok() { }
+            if self.reader_alive.send(false).is_ok() {}
 
             // Wait for the thread to be down
             if let Some(thread_handle) = self.reading_thread.take() {

--- a/src/pty/conpty.rs
+++ b/src/pty/conpty.rs
@@ -3,15 +3,15 @@
 /// This backend is available on Windows 10 starting from build number 1809.
 
 // Actual implementation if winpty is available
-#[cfg(feature="conpty")]
+#[cfg(feature = "conpty")]
 mod pty_impl;
 
-#[cfg(feature="conpty")]
+#[cfg(feature = "conpty")]
 pub use pty_impl::ConPTY;
 
 // Default implementation if winpty is not available
-#[cfg(not(feature="conpty"))]
+#[cfg(not(feature = "conpty"))]
 mod default_impl;
 
-#[cfg(not(feature="conpty"))]
+#[cfg(not(feature = "conpty"))]
 pub use default_impl::ConPTY;

--- a/src/pty/conpty/default_impl.rs
+++ b/src/pty/conpty/default_impl.rs
@@ -1,5 +1,6 @@
-
+use parking_lot::Mutex;
 use std::ffi::OsString;
+use std::sync::Arc;
 
 // Default implementation if winpty is not available
 use crate::pty::{PTYArgs, PTYImpl};
@@ -7,11 +8,17 @@ use crate::pty::{PTYArgs, PTYImpl};
 pub struct ConPTY {}
 
 impl PTYImpl for ConPTY {
-    fn new(_args: &PTYArgs) -> Result<Box<dyn PTYImpl>, OsString> {
+    fn new(_args: &PTYArgs) -> Result<Arc<Mutex<dyn PTYImpl>>, OsString> {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 
-    fn spawn(&mut self, _appname: OsString, _cmdline: Option<OsString>, _cwd: Option<OsString>, _env: Option<OsString>) -> Result<bool, OsString> {
+    fn spawn(
+        &self,
+        _appname: OsString,
+        _cmdline: Option<OsString>,
+        _cwd: Option<OsString>,
+        _env: Option<OsString>,
+    ) -> Result<bool, OsString> {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 

--- a/src/pty/winpty.rs
+++ b/src/pty/winpty.rs
@@ -2,25 +2,24 @@
 /// [winpty](https://github.com/rprichard/winpty) as its implementation.
 /// This backend is useful as a fallback implementation to the newer ConPTY
 /// backend, which is only available on Windows 10 starting on build number 1809.
-
 use bitflags::bitflags;
 use enum_primitive_derive::Primitive;
 
 // Actual implementation if winpty is available
-#[cfg(feature="winpty")]
+#[cfg(feature = "winpty")]
 mod pty_impl;
 
-#[cfg(feature="winpty")]
+#[cfg(feature = "winpty")]
 mod bindings;
 
-#[cfg(feature="winpty")]
+#[cfg(feature = "winpty")]
 pub use pty_impl::WinPTY;
 
 // Default implementation if winpty is not available
-#[cfg(not(feature="winpty"))]
+#[cfg(not(feature = "winpty"))]
 mod default_impl;
 
-#[cfg(not(feature="winpty"))]
+#[cfg(not(feature = "winpty"))]
 pub use default_impl::WinPTY;
 
 ///  Mouse capture settings for the winpty backend.

--- a/src/pty/winpty/bindings.rs
+++ b/src/pty/winpty/bindings.rs
@@ -1,6 +1,5 @@
 #![allow(non_camel_case_types)]
 /// WinPTY C bindings.
-
 /*
  * Copyright (c) 2011-2016 Ryan Prichard
  *
@@ -22,7 +21,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-
 //use std::ptr;
 // use std::ffi::c_void;
 use std::os::windows::raw::HANDLE;
@@ -145,7 +143,8 @@ extern "C" {
         cmdline: *const u16,
         cwd: *const u16,
         env: *const u16,
-        err: *mut winpty_error_ptr_t) -> *mut winpty_spawn_config_t;
+        err: *mut winpty_error_ptr_t,
+    ) -> *mut winpty_spawn_config_t;
 
     /// Free the cfg object after passing it to winpty_spawn.
     pub fn winpty_spawn_config_free(cfg: *mut winpty_spawn_config_t);
@@ -179,13 +178,19 @@ extern "C" {
         process_handle: *mut HANDLE,
         thread_handle: *mut HANDLE,
         create_process_error: *mut u32,
-        err: *mut winpty_error_ptr_t) -> bool;
+        err: *mut winpty_error_ptr_t,
+    ) -> bool;
 }
 
 // winpty agent RPC calls: everything else
 extern "C" {
     /// Change the size of the Windows console window.
-    pub fn winpty_set_size(wp: *mut winpty_t, cols: i32, rows: i32, err: *mut winpty_error_ptr_t) -> bool;
+    pub fn winpty_set_size(
+        wp: *mut winpty_t,
+        cols: i32,
+        rows: i32,
+        err: *mut winpty_error_ptr_t,
+    ) -> bool;
 
     /// Frees the winpty_t object and the OS resources contained in it.  This
     /// call breaks the connection with the agent, which should then close its

--- a/src/pty/winpty/default_impl.rs
+++ b/src/pty/winpty/default_impl.rs
@@ -1,40 +1,63 @@
-
-use std::ffi::OsString;
 use crate::pty::{PTYArgs, PTYImpl};
+use parking_lot::Mutex;
+use std::ffi::OsString;
+use std::sync::Arc;
 
 pub struct WinPTY {}
 
 impl PTYImpl for WinPTY {
-    fn new(_args: &PTYArgs) -> Result<Box<dyn PTYImpl>, OsString> {
-        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+    fn new(_args: &PTYArgs) -> Result<Arc<Mutex<dyn PTYImpl>>, OsString> {
+        Err(OsString::from(
+            "winpty_rs was compiled without WinPTY enabled",
+        ))
     }
 
-    fn spawn(&mut self, _appname: OsString, _cmdline: Option<OsString>, _cwd: Option<OsString>, _env: Option<OsString>) -> Result<bool, OsString> {
-        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+    fn spawn(
+        &mut self,
+        _appname: OsString,
+        _cmdline: Option<OsString>,
+        _cwd: Option<OsString>,
+        _env: Option<OsString>,
+    ) -> Result<bool, OsString> {
+        Err(OsString::from(
+            "winpty_rs was compiled without WinPTY enabled",
+        ))
     }
 
     fn set_size(&self, _cols: i32, _rows: i32) -> Result<(), OsString> {
-        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+        Err(OsString::from(
+            "winpty_rs was compiled without WinPTY enabled",
+        ))
     }
 
     fn read(&self, _length: u32, _blocking: bool) -> Result<OsString, OsString> {
-        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+        Err(OsString::from(
+            "winpty_rs was compiled without WinPTY enabled",
+        ))
     }
 
     fn write(&self, _buf: OsString) -> Result<u32, OsString> {
-        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+        Err(OsString::from(
+            "winpty_rs was compiled without WinPTY enabled",
+        ))
     }
 
     fn is_eof(&self) -> Result<bool, OsString> {
-        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+        Err(OsString::from(
+            "winpty_rs was compiled without WinPTY enabled",
+        ))
     }
 
     fn get_exitstatus(&self) -> Result<Option<u32>, OsString> {
-        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+        Err(OsString::from(
+            "winpty_rs was compiled without WinPTY enabled",
+        ))
     }
 
     fn is_alive(&self) -> Result<bool, OsString> {
-        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+        Err(OsString::from(
+            "winpty_rs was compiled without WinPTY enabled",
+        ))
     }
 
     fn get_pid(&self) -> u32 {
@@ -46,6 +69,8 @@ impl PTYImpl for WinPTY {
     }
 
     fn wait_for_exit(&self) -> Result<bool, OsString> {
-        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+        Err(OsString::from(
+            "winpty_rs was compiled without WinPTY enabled",
+        ))
     }
 }

--- a/tests/conpty.rs
+++ b/tests/conpty.rs
@@ -1,10 +1,10 @@
-#![cfg(feature="conpty")]
+#![cfg(feature = "conpty")]
 
+use regex::Regex;
 use std::ffi::OsString;
 use std::{thread, time};
-use regex::Regex;
 
-use winptyrs::{PTY, PTYArgs, PTYBackend, MouseMode, AgentConfig};
+use winptyrs::{AgentConfig, MouseMode, PTYArgs, PTYBackend, PTY};
 
 #[test]
 #[ignore]
@@ -14,7 +14,7 @@ fn spawn_conpty() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
@@ -32,7 +32,7 @@ fn read_write_conpty() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
@@ -55,7 +55,8 @@ fn read_write_conpty() {
     assert!(regex.is_match(output_str));
 
     let echo_regex = Regex::new(".*echo \"This is a test stri.*").unwrap();
-    pty.write(OsString::from("echo \"This is a test string 😁\"")).unwrap();
+    pty.write(OsString::from("echo \"This is a test string 😁\""))
+        .unwrap();
 
     output_str = "";
     while !echo_regex.is_match(output_str) {
@@ -88,14 +89,15 @@ fn set_size_conpty() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
     let mut pty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
     pty.spawn(appname, None, None, None).unwrap();
 
-    pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into()).unwrap();
+    pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into())
+        .unwrap();
     let regex = Regex::new(r".*Width.*").unwrap();
     let mut output_str = "";
     let mut out: OsString;
@@ -134,7 +136,8 @@ fn set_size_conpty() {
 
     let mut count = 0;
     while count < 5 || (cols != 90 && rows != 30) {
-        pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into()).unwrap();
+        pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into())
+            .unwrap();
         let regex = Regex::new(r".*Width.*").unwrap();
         let mut output_str = "";
         let mut out: OsString;
@@ -171,7 +174,7 @@ fn is_alive_exitstatus_conpty() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
@@ -197,7 +200,7 @@ fn wait_for_exit() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
@@ -222,12 +225,20 @@ fn check_eof_output() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("python.exe");
     let mut pty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
-    pty.spawn(appname, Some(OsString::from("-c \"print(\';\'.join([str(i) for i in range(0, 2048)]))\"")), None, None).unwrap();
+    pty.spawn(
+        appname,
+        Some(OsString::from(
+            "-c \"print(\';\'.join([str(i) for i in range(0, 2048)]))\"",
+        )),
+        None,
+        None,
+    )
+    .unwrap();
     assert!(pty.is_alive().unwrap());
 
     let mut collect_vec: Vec<String> = Vec::new();
@@ -237,7 +248,9 @@ fn check_eof_output() {
         let out_wrapped = pty.read(1000, false);
         match out_wrapped {
             Ok(out) => collect_vec.push(out.into_string().unwrap()),
-            Err(_) => {valid = false;}
+            Err(_) => {
+                valid = false;
+            }
         }
     }
 
@@ -246,5 +259,4 @@ fn check_eof_output() {
 
     println!("{:?}", output_str);
     let _ = pty.wait_for_exit();
-
 }

--- a/tests/winpty.rs
+++ b/tests/winpty.rs
@@ -1,10 +1,10 @@
-#![cfg(feature="winpty")]
+#![cfg(feature = "winpty")]
 
-use std::ffi::OsString;
-use std::env;
 use regex::Regex;
+use std::env;
+use std::ffi::OsString;
 
-use winptyrs::{PTY, PTYArgs, PTYBackend, MouseMode, AgentConfig};
+use winptyrs::{AgentConfig, MouseMode, PTYArgs, PTYBackend, PTY};
 
 #[test]
 fn spawn_winpty() {
@@ -13,7 +13,7 @@ fn spawn_winpty() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
@@ -28,7 +28,7 @@ fn read_write_winpty() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
@@ -47,7 +47,8 @@ fn read_write_winpty() {
     assert!(regex.is_match(output_str));
 
     let echo_regex = Regex::new(".*echo \"This is a test stri.*").unwrap();
-    pty.write(OsString::from("echo \"This is a test string\"")).unwrap();
+    pty.write(OsString::from("echo \"This is a test string\""))
+        .unwrap();
 
     output_str = "";
     while !echo_regex.is_match(output_str) {
@@ -77,14 +78,15 @@ fn set_size_winpty() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
     let mut pty = PTY::new_with_backend(&pty_args, PTYBackend::WinPTY).unwrap();
     pty.spawn(appname, None, None, None).unwrap();
 
-    pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into()).unwrap();
+    pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into())
+        .unwrap();
     let regex = Regex::new(r".*Width.*").unwrap();
     let mut output_str = "";
     let mut out: OsString;
@@ -117,7 +119,8 @@ fn set_size_winpty() {
 
     let mut count = 0;
     while count < 5 || (cols != 90 && rows != 30) {
-        pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into()).unwrap();
+        pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into())
+            .unwrap();
         let regex = Regex::new(r".*Width.*").unwrap();
         let mut output_str = "";
         let mut out: OsString;
@@ -141,8 +144,8 @@ fn set_size_winpty() {
         count += 1;
     }
     // if &env::var("CI").unwrap_or("0".to_owned()) == "0" {
-        assert_eq!(cols, 90);
-        assert_eq!(rows, 30);
+    assert_eq!(cols, 90);
+    assert_eq!(rows, 30);
     // }
 }
 
@@ -153,7 +156,7 @@ fn is_alive_exitstatus_winpty() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
@@ -172,7 +175,6 @@ fn is_alive_exitstatus_winpty() {
     assert_eq!(pty.get_exitstatus().unwrap(), Some(0))
 }
 
-
 #[test]
 fn wait_for_exit() {
     let pty_args = PTYArgs {
@@ -180,7 +182,7 @@ fn wait_for_exit() {
         rows: 25,
         mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
         timeout: 10000,
-        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
     };
 
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");


### PR DESCRIPTION
To resolve this issue： https://github.com/andfoy/winpty-rs/issues/89,

just replace all `Box<dyn PTYImpl>` to `Arc<Mutex<dyn PTYImpl>>` to use `PTY` in multi thread.

`PTYImpl` is `Send + Sync`, so seems it is reasonable to do such a change.

I use this change here： https://github.com/uuhan/workhorse/blob/8a6b394b8a411f179904fabfb9a27d97e5476d45/horsed/src/ssh/mod.rs#L683

It works pretty well.

Feel free to close this pr, it has many default `cargo fmt` changes.