### PR TITLE
Optimize read performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "2.3"
 which = "7.0.0"
 
 [dependencies.windows]
-version = "0.59.0"
+version = "0.60.0"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ as well to get information about its status.
 pty.spawn(cmd, None, None, None).unwrap();
 
 // Read the spawned process standard output (non-blocking).
-let output = pty.read(1000, false);
+let output = pty.read(false);
 
 // Write to the spawned process standard input.
 let to_write = OsString::from("echo \"some str\"\r\n");

--- a/src/examples/conpty.rs
+++ b/src/examples/conpty.rs
@@ -18,13 +18,13 @@ fn main() {
             println!("{:?}", appname);
             match pty.spawn(appname, None, None, None) {
                 Ok(_) => {
-                    let mut output = pty.read(1000, false);
+                    let mut output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
@@ -35,13 +35,13 @@ fn main() {
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
@@ -57,13 +57,13 @@ fn main() {
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)

--- a/src/examples/winpty.rs
+++ b/src/examples/winpty.rs
@@ -18,13 +18,13 @@ fn main() {
             println!("{:?}", appname);
             match pty.spawn(appname, None, None, None) {
                 Ok(_) => {
-                    let mut output = pty.read(1000, false);
+                    let mut output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
@@ -35,13 +35,13 @@ fn main() {
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
@@ -57,13 +57,13 @@ fn main() {
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,155 @@ extern crate num_traits;
 pub mod pty;
 // mod pty_spawn;
 pub use pty::{PTY, PTYArgs, PTYBackend, MouseMode, AgentConfig};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+    use std::thread::sleep;
+    use std::time::Duration;
+    use std::ffi::OsString;
+
+    #[test]
+    fn test_write_performance() {
+        // Initialize PTY with default arguments
+        let mut args = PTYArgs::default();
+        args.cols = 80;
+        args.rows = 24;
+        let mut pty = PTY::new_with_backend(&args, PTYBackend::ConPTY).unwrap();
+
+        // Spawn cmd.exe
+        let cmd = OsString::from("c:\\windows\\system32\\cmd.exe");
+        pty.spawn(cmd, None, None, None).unwrap();
+
+        // Wait for process to start
+        sleep(Duration::from_millis(1000));
+
+        // Test data
+        let test_data = OsString::from("echo test\r\n");
+        let iterations = 100;
+        let mut total_time = Duration::from_secs(0);
+
+        // Perform write performance test
+        for i in 0..iterations {
+            let start = Instant::now();
+            pty.write(test_data.clone()).unwrap();
+            let duration = start.elapsed();
+            total_time += duration;
+            println!("Write {}: {:?}", i + 1, duration);
+        }
+
+        // Calculate and print statistics
+        let avg_time = total_time.as_secs_f64() / iterations as f64;
+        println!("\nWrite Performance Test Results:");
+        println!("Total time: {:?}", total_time);
+        println!("Average time per write: {:.2}ms", avg_time * 1000.0);
+        println!("Total writes: {}", iterations);
+    }
+
+    #[test]
+    fn test_read_performance() {
+        // Initialize PTY with default arguments
+        let mut args = PTYArgs::default();
+        args.cols = 80;
+        args.rows = 24;
+        let mut pty = PTY::new_with_backend(&args, PTYBackend::ConPTY).unwrap();
+
+        // Spawn cmd.exe with a command that produces continuous output
+        let cmd = OsString::from("c:\\windows\\system32\\cmd.exe");
+        pty.spawn(cmd, Some("/c echo test".into()), None, None).unwrap();
+
+        // Wait for process to start
+        sleep(Duration::from_millis(1000));
+
+        // Test parameters
+        let iterations = 100;
+        let mut total_time = Duration::from_secs(0);
+        let mut total_bytes = 0;
+        let mut successful_reads = 0;
+
+        // Perform read performance test
+        for i in 0..iterations {
+            let start = Instant::now();
+            match pty.read(false) {
+                Ok(data) => {
+                    let duration = start.elapsed();
+                    total_time += duration;
+                    total_bytes += data.len();
+                    successful_reads += 1;
+                    println!("Read {}: {:?}, bytes: {}", i + 1, duration, data.len());
+                }
+                Err(e) => {
+                    println!("Read {} failed: {:?}", i + 1, e);
+                }
+            }
+        }
+
+        // Calculate and print statistics
+        let avg_time = if successful_reads > 0 {
+            total_time.as_secs_f64() / successful_reads as f64
+        } else {
+            0.0
+        };
+        let avg_bytes = if successful_reads > 0 {
+            total_bytes as f64 / successful_reads as f64
+        } else {
+            0.0
+        };
+
+        println!("\nRead Performance Test Results:");
+        println!("Total time: {:?}", total_time);
+        println!("Average time per read: {:.2}ms", avg_time * 1000.0);
+        println!("Total bytes read: {}", total_bytes);
+        println!("Average bytes per read: {:.2}", avg_bytes);
+        println!("Successful reads: {}", successful_reads);
+    }
+
+    #[test]
+    fn test_nonblocking_read_performance() {
+        // Initialize PTY with default arguments
+        let mut args = PTYArgs::default();
+        args.cols = 80;
+        args.rows = 24;
+        
+        let mut pty = PTY::new_with_backend(&args, PTYBackend::ConPTY).unwrap();
+        pty.spawn(
+            "cmd.exe".into(),
+            Some("/c echo test".into()),
+            None,
+            None
+        ).unwrap();
+
+        // Wait for process to start
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        let start = Instant::now();
+        let mut total_bytes = 0;
+        let mut read_count = 0;
+        let mut empty_reads = 0;
+
+        // Read 100 times in non-blocking mode
+        for _ in 0..100 {
+            match pty.read(false) {
+                Ok(data) => {
+                    if data.is_empty() {
+                        empty_reads += 1;
+                    } else {
+                        total_bytes += data.len();
+                        read_count += 1;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+
+        let duration = start.elapsed();
+        println!("Non-blocking read performance test:");
+        println!("Total time: {:?}", duration);
+        println!("Average time per read: {:?}ms", duration.as_secs_f64() * 1000.0 / (read_count + empty_reads) as f64);
+        println!("Total bytes read: {}", total_bytes);
+        println!("Successful reads: {}", read_count);
+        println!("Empty reads: {}", empty_reads);
+        println!("Average bytes per successful read: {}", if read_count > 0 { total_bytes / read_count } else { 0 });
+    }
+}

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -242,7 +242,7 @@ impl PTY {
 		self.backend
 	}
 
-	/// Read from the process standard output.
+	/// Read all available characters from the standard output of a process.
     ///
     /// # Arguments
     /// * `blocking` - If true, wait for data to be available. If false, return immediately if no data is available.
@@ -252,7 +252,7 @@ impl PTY {
     /// * `Err(OsString)` - If EOF is reached or an error occurs
     ///
     /// # Notes
-    /// * The actual read operation happens in a background thread with a fixed buffer size
+    /// * The actual read operation happens in a background thread
     /// * The returned data is represented using a [`OsString`] since Windows operates over `u16` strings
     pub fn read(&self, blocking: bool) -> Result<OsString, OsString> {
         self.pty.read(blocking)

--- a/src/pty/conpty/default_impl.rs
+++ b/src/pty/conpty/default_impl.rs
@@ -1,4 +1,3 @@
-
 use std::ffi::OsString;
 
 // Default implementation if winpty is not available
@@ -19,7 +18,7 @@ impl PTYImpl for ConPTY {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 
-    fn read(&self, _length: u32, _blocking: bool) -> Result<OsString, OsString> {
+    fn read(&self, _blocking: bool) -> Result<OsString, OsString> {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 

--- a/src/pty/conpty/pty_impl.rs
+++ b/src/pty/conpty/pty_impl.rs
@@ -331,8 +331,8 @@ impl PTYImpl for ConPTY {
         }
     }
 
-    fn read(&self, length: u32, blocking: bool) -> Result<OsString, OsString> {
-        self.process.read(length, blocking)
+    fn read(&self, blocking: bool) -> Result<OsString, OsString> {
+        self.process.read(blocking)
     }
 
     fn write(&self, buf: OsString) -> Result<u32, OsString> {

--- a/src/pty/winpty.rs
+++ b/src/pty/winpty.rs
@@ -24,12 +24,12 @@ mod default_impl;
 pub use default_impl::WinPTY;
 
 ///  Mouse capture settings for the winpty backend.
-#[derive(Primitive)]
+#[derive(Primitive, Clone, Debug)]
 #[allow(non_camel_case_types)]
 pub enum MouseMode {
     /// QuickEdit mode is initially disabled, and the agent does not send mouse
     /// mode sequences to the terminal.  If it receives mouse input, though, it
-    // still writes MOUSE_EVENT_RECORD values into CONIN.
+    /// still writes MOUSE_EVENT_RECORD values into CONIN.
     WINPTY_MOUSE_MODE_NONE = 0,
 
     /// QuickEdit mode is initially enabled.  As CONIN enters or leaves mouse
@@ -46,6 +46,7 @@ pub enum MouseMode {
 
 bitflags! {
     /// General configuration settings for the winpty backend.
+    #[derive(Clone, Debug)]
     pub struct AgentConfig: u64 {
         /// Create a new screen buffer (connected to the "conerr" terminal pipe) and
         /// pass it to child processes as the STDERR handle.  This flag also prevents

--- a/src/pty/winpty/default_impl.rs
+++ b/src/pty/winpty/default_impl.rs
@@ -1,4 +1,3 @@
-
 use std::ffi::OsString;
 use crate::pty::{PTYArgs, PTYImpl};
 
@@ -17,7 +16,7 @@ impl PTYImpl for WinPTY {
         Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
     }
 
-    fn read(&self, _length: u32, _blocking: bool) -> Result<OsString, OsString> {
+    fn read(&self, _blocking: bool) -> Result<OsString, OsString> {
         Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
     }
 

--- a/src/pty/winpty/pty_impl.rs
+++ b/src/pty/winpty/pty_impl.rs
@@ -1,7 +1,7 @@
 /// Actual WinPTY backend implementation.
 
-use windows::Win32::Foundation::{HANDLE};
-use windows::core::{PCWSTR};
+use windows::Win32::Foundation::HANDLE;
+use windows::core::PCWSTR;
 use windows::Win32::Storage::FileSystem::{
     CreateFileW, FILE_GENERIC_READ, FILE_SHARE_NONE,
     OPEN_EXISTING, FILE_GENERIC_WRITE,
@@ -279,8 +279,8 @@ impl PTYImpl for WinPTY {
         self.ptr.set_size(cols, rows)
     }
 
-    fn read(&self, length: u32, blocking: bool) -> Result<OsString, OsString> {
-        self.process.read(length, blocking)
+    fn read(&self, blocking: bool) -> Result<OsString, OsString> {
+        self.process.read(blocking)
     }
 
     fn write(&self, buf: OsString) -> Result<u32, OsString> {

--- a/tests/conpty.rs
+++ b/tests/conpty.rs
@@ -46,7 +46,7 @@ fn read_write_conpty() {
     let mut tries = 0;
 
     while !regex.is_match(output_str) && tries < 5 {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
         println!("{:?}", output_str);
         tries += 1;
@@ -59,7 +59,7 @@ fn read_write_conpty() {
 
     output_str = "";
     while !echo_regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
         println!("{:?}", output_str);
     }
@@ -71,7 +71,7 @@ fn read_write_conpty() {
 
     output_str = "";
     while !out_regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
         println!("{:?}", output_str);
     }
@@ -101,7 +101,7 @@ fn set_size_conpty() {
     let mut out: OsString;
 
     while !regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -140,7 +140,7 @@ fn set_size_conpty() {
         let mut out: OsString;
 
         while !regex.is_match(output_str) {
-            out = pty.read(1000, false).unwrap();
+            out = pty.read(false).unwrap();
             output_str = out.to_str().unwrap();
         }
 
@@ -234,7 +234,7 @@ fn check_eof_output() {
     let mut valid = true;
 
     while valid {
-        let out_wrapped = pty.read(1000, false);
+        let out_wrapped = pty.read(false);
         match out_wrapped {
             Ok(out) => collect_vec.push(out.into_string().unwrap()),
             Err(_) => {valid = false;}

--- a/tests/winpty.rs
+++ b/tests/winpty.rs
@@ -40,7 +40,7 @@ fn read_write_winpty() {
     let mut out: OsString;
 
     while !regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -51,7 +51,7 @@ fn read_write_winpty() {
 
     output_str = "";
     while !echo_regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -62,7 +62,7 @@ fn read_write_winpty() {
 
     output_str = "";
     while !out_regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -90,7 +90,7 @@ fn set_size_winpty() {
     let mut out: OsString;
 
     while !regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -123,7 +123,7 @@ fn set_size_winpty() {
         let mut out: OsString;
 
         while !regex.is_match(output_str) {
-            out = pty.read(1000, false).unwrap();
+            out = pty.read(false).unwrap();
             output_str = out.to_str().unwrap();
         }
 


### PR DESCRIPTION
This change results in a substantial performance boost for PTY read operations.

# Performance Comparison: Non-Blocking Read Test

| Metric                         | Before Optimization | After Optimization |
| ------------------------------ | ------------------- | ------------------ |
| **Total time**                 | 106.9877 ms         | 15.4 µs            |
| **Average time per read**      | 106.9877 ms         | 0.0077 ms          |
| **Total bytes read**           | 76                  | 76                 |

