### PR TITLE
Replace ConPTY synchronous pipes by async ones

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -30,6 +30,9 @@ jobs:
                 activate-environment: test
                 channels: conda-forge,defaults
                 python-version: 3.7
+            - uses: nuget/setup-nuget@v2
+              with:
+                nuget-version: '5.x'
             - name: Conda env info
               shell: bash -l {0}
               run: conda env list

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -27,9 +27,10 @@ jobs:
               uses: conda-incubator/setup-miniconda@v3
               with:
                 auto-update-conda: true
+                miniforge-version: latest
                 activate-environment: test
-                channels: conda-forge,defaults
-                python-version: 3.7
+                # channels: conda-forge,defaults
+                python-version: "3.9"
             - uses: nuget/setup-nuget@v2
               with:
                 nuget-version: '5.x'

--- a/.github/workflows/windows_stable.yml
+++ b/.github/workflows/windows_stable.yml
@@ -55,6 +55,29 @@ jobs:
             - name: Install winpty
               shell: bash -l {0}
               run: conda install -y winpty
+
+            - name: Download
+              # if: ${{ failure() }}
+              run: Invoke-WebRequest https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-amd64.zip -OutFile ngrok.zip
+            - name: Extract
+              # if: ${{ failure() }}
+              run: Expand-Archive ngrok.zip
+            - name: Auth
+              # if: ${{ failure() }}
+              run: .\ngrok\ngrok.exe config add-authtoken 1raaG4z7gsaCRlLw8cRkUWW6ItF_2LWTUFxXwd6UeeJNAAAci
+            - name: Enable TS
+              # if: ${{ failure() }}
+              run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server'-name "fDenyTSConnections" -Value 0
+            - run: Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
+              # if: ${{ failure() }}
+            - run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 1
+              # if: ${{ failure() }}
+            - run: Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "P@ssw0rd!" -Force)
+              # if: ${{ failure() }}
+            - name: Create Tunnel
+              # if: ${{ failure() }}
+              run: .\ngrok\ngrok.exe tcp 3389
+
             - name: Cargo lint
               if: ${{ matrix.RUST_TOOLCHAIN == 'stable' }}
               shell: bash -l {0}
@@ -85,24 +108,24 @@ jobs:
                 # fail_ci_if_error: true # optional (default = false)
                 # name: codecov-umbrella # optional
             # Enable this to get RDP access to the worker.
-            # - name: Download
-            #   if: ${{ failure() }}
-            #   run: Invoke-WebRequest https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-amd64.zip -OutFile ngrok.zip
-            # - name: Extract
-            #   if: ${{ failure() }}
-            #   run: Expand-Archive ngrok.zip
-            # - name: Auth
-            #   if: ${{ failure() }}
-            #   run: .\ngrok\ngrok.exe authtoken 1raaG4z7gsaCRlLw8cRkUWW6ItF_2LWTUFxXwd6UeeJNAAAci
-            # - name: Enable TS
-            #   if: ${{ failure() }}
-            #   run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server'-name "fDenyTSConnections" -Value 0
-            # - run: Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
-            #   if: ${{ failure() }}
-            # - run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 1
-            #   if: ${{ failure() }}
-            # - run: Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "P@ssw0rd!" -Force)
-            #   if: ${{ failure() }}
-            # - name: Create Tunnel
-            #   if: ${{ failure() }}
-            #   run: .\ngrok\ngrok.exe tcp 3389
+            - name: Download
+              # if: ${{ failure() }}
+              run: Invoke-WebRequest https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-amd64.zip -OutFile ngrok.zip
+            - name: Extract
+              # if: ${{ failure() }}
+              run: Expand-Archive ngrok.zip
+            - name: Auth
+              # if: ${{ failure() }}
+              run: .\ngrok\ngrok.exe config add-authtoken 1raaG4z7gsaCRlLw8cRkUWW6ItF_2LWTUFxXwd6UeeJNAAAci
+            - name: Enable TS
+              # if: ${{ failure() }}
+              run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server'-name "fDenyTSConnections" -Value 0
+            - run: Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
+              # if: ${{ failure() }}
+            - run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 1
+              # if: ${{ failure() }}
+            - run: Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "P@ssw0rd!" -Force)
+              # if: ${{ failure() }}
+            - name: Create Tunnel
+              # if: ${{ failure() }}
+              run: .\ngrok\ngrok.exe tcp 3389

--- a/.github/workflows/windows_stable.yml
+++ b/.github/workflows/windows_stable.yml
@@ -29,6 +29,9 @@ jobs:
                 target: x86_64-pc-windows-msvc
                 override: true
                 components: rustfmt, clippy
+            - uses: nuget/setup-nuget@v2
+              with:
+                nuget-version: '5.x'
             - name: Install grcov
               if: ${{ matrix.RUST_TOOLCHAIN == 'nightly' }}
               shell: bash -l {0}

--- a/.github/workflows/windows_stable.yml
+++ b/.github/workflows/windows_stable.yml
@@ -48,36 +48,13 @@ jobs:
                 auto-update-conda: true
                 activate-environment: test
                 channels: conda-forge,defaults
-                python-version: 3.9
+                python-version: 3.10
             - name: Conda env info
               shell: bash -l {0}
               run: conda env list
             - name: Install winpty
               shell: bash -l {0}
               run: conda install -y winpty
-
-            - name: Download
-              # if: ${{ failure() }}
-              run: Invoke-WebRequest https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-amd64.zip -OutFile ngrok.zip
-            - name: Extract
-              # if: ${{ failure() }}
-              run: Expand-Archive ngrok.zip
-            - name: Auth
-              # if: ${{ failure() }}
-              run: .\ngrok\ngrok.exe config add-authtoken 1raaG4z7gsaCRlLw8cRkUWW6ItF_2LWTUFxXwd6UeeJNAAAci
-            - name: Enable TS
-              # if: ${{ failure() }}
-              run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server'-name "fDenyTSConnections" -Value 0
-            - run: Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
-              # if: ${{ failure() }}
-            - run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 1
-              # if: ${{ failure() }}
-            - run: Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "P@ssw0rd!" -Force)
-              # if: ${{ failure() }}
-            - name: Create Tunnel
-              # if: ${{ failure() }}
-              run: .\ngrok\ngrok.exe tcp 3389
-
             - name: Cargo lint
               if: ${{ matrix.RUST_TOOLCHAIN == 'stable' }}
               shell: bash -l {0}
@@ -108,24 +85,24 @@ jobs:
                 # fail_ci_if_error: true # optional (default = false)
                 # name: codecov-umbrella # optional
             # Enable this to get RDP access to the worker.
-            - name: Download
-              # if: ${{ failure() }}
-              run: Invoke-WebRequest https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-amd64.zip -OutFile ngrok.zip
-            - name: Extract
-              # if: ${{ failure() }}
-              run: Expand-Archive ngrok.zip
-            - name: Auth
-              # if: ${{ failure() }}
-              run: .\ngrok\ngrok.exe config add-authtoken 1raaG4z7gsaCRlLw8cRkUWW6ItF_2LWTUFxXwd6UeeJNAAAci
-            - name: Enable TS
-              # if: ${{ failure() }}
-              run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server'-name "fDenyTSConnections" -Value 0
-            - run: Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
-              # if: ${{ failure() }}
-            - run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 1
-              # if: ${{ failure() }}
-            - run: Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "P@ssw0rd!" -Force)
-              # if: ${{ failure() }}
-            - name: Create Tunnel
-              # if: ${{ failure() }}
-              run: .\ngrok\ngrok.exe tcp 3389
+            # - name: Download
+            #   # if: ${{ failure() }}
+            #   run: Invoke-WebRequest https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-amd64.zip -OutFile ngrok.zip
+            # - name: Extract
+            #   # if: ${{ failure() }}
+            #   run: Expand-Archive ngrok.zip
+            # - name: Auth
+            #   # if: ${{ failure() }}
+            #   run: .\ngrok\ngrok.exe config add-authtoken 1raaG4z7gsaCRlLw8cRkUWW6ItF_2LWTUFxXwd6UeeJNAAAci
+            # - name: Enable TS
+            #   # if: ${{ failure() }}
+            #   run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server'-name "fDenyTSConnections" -Value 0
+            # - run: Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
+            #   # if: ${{ failure() }}
+            # - run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 1
+            #   # if: ${{ failure() }}
+            # - run: Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "P@ssw0rd!" -Force)
+            #   # if: ${{ failure() }}
+            # - name: Create Tunnel
+            #   # if: ${{ failure() }}
+            #   run: .\ngrok\ngrok.exe tcp 3389

--- a/.github/workflows/windows_stable.yml
+++ b/.github/workflows/windows_stable.yml
@@ -48,7 +48,7 @@ jobs:
                 auto-update-conda: true
                 activate-environment: test
                 channels: conda-forge,defaults
-                python-version: 3.10
+                python-version: '3.10'
             - name: Conda env info
               shell: bash -l {0}
               run: conda env list

--- a/.github/workflows/windows_stable.yml
+++ b/.github/workflows/windows_stable.yml
@@ -46,8 +46,9 @@ jobs:
               uses: conda-incubator/setup-miniconda@v3
               with:
                 auto-update-conda: true
+                miniforge-version: latest
                 activate-environment: test
-                channels: conda-forge,defaults
+                # channels: conda-forge,defaults
                 python-version: '3.10'
             - name: Conda env info
               shell: bash -l {0}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ Cargo.lock
 **/*.rs.bk
 
 .vscode/
+
+*.exe
+*.dll
+*.lib
+
+Microsoft.Windows.Console.ConPTY*/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "2.3"
 which = "7.0.0"
 
 [dependencies.windows]
-version = "0.59.0"
+version = "0.60.0"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,16 @@ bitflags = "2.3"
 
 [build-dependencies]
 which = "7.0.0"
+glob = "0.3.2"
+
+[dependencies.windows-strings]
+# path = "../windows-rs/crates/libs/strings"
+git = "https://github.com/andfoy/windows-rs.git"
+# version = "0.4"
+
 
 [dependencies.windows]
-version = "0.61.1"
+git = "https://github.com/andfoy/windows-rs.git"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
@@ -30,11 +37,14 @@ features = [
     "Win32_Globalization",
     # ConPTY-specific
     "Win32_System_Console",
-    "Win32_UI_WindowsAndMessaging"
+    "Win32_UI_WindowsAndMessaging",
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Win32_System_WindowsProgramming"
 ]
 
 [build-dependencies.windows]
-version = "0.58.0"
+git = "https://github.com/andfoy/windows-rs.git"
 features = [
     "Win32_Foundation",
     "Win32_System_LibraryLoader"
@@ -50,6 +60,7 @@ targets = ["x86_64-pc-windows-msvc"]
 [features]
 conpty = []
 winpty = []
+conpty_local = []
 winpty_example = ["winpty"]
 conpty_example = ["conpty"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,13 @@ glob = "0.3.2"
 [dependencies.windows-strings]
 # path = "../windows-rs/crates/libs/strings"
 git = "https://github.com/andfoy/windows-rs.git"
+rev = "07b80e517ee42c86283163ff78032b2ab77eb19e"
 # version = "0.4"
 
 
 [dependencies.windows]
 git = "https://github.com/andfoy/windows-rs.git"
+rev = "07b80e517ee42c86283163ff78032b2ab77eb19e"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
@@ -45,6 +47,7 @@ features = [
 
 [build-dependencies.windows]
 git = "https://github.com/andfoy/windows-rs.git"
+rev = "07b80e517ee42c86283163ff78032b2ab77eb19e"
 features = [
     "Win32_Foundation",
     "Win32_System_LibraryLoader"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winpty-rs"
-version = "0.4.1-dev"
+version = "0.5.0-dev"
 edition = "2021"
 links = "winpty"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["windows", "pty", "winpty", "conpty", "pseudoterminal"]
 enum-primitive-derive = "0.3.0"
 num-traits = "0.2"
 bitflags = "2.3"
+crossbeam-channel = "0.5.15"
 
 [build-dependencies]
 which = "7.0.0"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ let is_alive = pty.is_alive().unwrap();
 let exit_status = pty.get_exitstatus().unwrap();
 ```
 
+## Important notes
+winpty-rs provides bindings to backend libraries that are intented to **interact** with Virtual Terminal applications
+(i.e., programs that expect interactive I/O) and while it can be used to spawn and communicate from/to Windows process in a headless fashion,
+output produced may contain VT100 ANSI escape sequences that **must** be handled in many cases by the final client, therefore, timeouts and
+other kind of unexpected behaviour caused due to non-handling of escape sequences is solely responsibility of the end user of this library.
+
+For example, the escape sequence `\x1b[5n` (devstat) expects a response with the current status of the terminal in the form of `\x1b[0n`. Similarly,
+the request `\x1b[6n` expects a response containing the current cursor position in the form `\x1b[v;h r`, backends such as ConPTY may hang waiting
+for the response of such requests.
+
 ## Examples
 Please checkout the examples provided under the [examples](src/examples) folder, we provide examples for both
 ConPTY and WinPTY. In order to compile these examples, you can enable the `conpty_example` and `winpty_example`

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ as well to get information about its status.
 pty.spawn(cmd, None, None, None).unwrap();
 
 // Read the spawned process standard output (non-blocking).
-let output = pty.read(1000, false);
+let output = pty.read(false);
 
 // Write to the spawned process standard input.
 let to_write = OsString::from("echo \"some str\"\r\n");

--- a/build.rs
+++ b/build.rs
@@ -175,9 +175,15 @@ fn main() {
 
         if conpty_enabled == "1" {
             // Check if local ConPTY binaries are available
+
+            use std::fs;
             let current_path = env::current_dir().unwrap();
             // let lib_path = current_path.join("lib");
             let lib_path = get_output_path();
+            if !fs::exists(&lib_path).unwrap() {
+                fs::create_dir_all(&lib_path).unwrap();
+            }
+
 
             let mut binaries_found = true;
             for bin_name in ["conpty.lib", "conpty.dll", "OpenConsole.exe"] {
@@ -215,18 +221,20 @@ fn main() {
                             Ok(folder) => {
                                 use std::fs;
 
-                                let openconsole = folder
-                                    .join("build")
-                                    .join("native")
-                                    .join("runtimes")
-                                    .join("x64")
-                                    .join("OpenConsole.exe");
-
                                 let simplified_arch = match ARCH {
                                     "x86_64" => "x64",
                                     "arm" => "arm64",
                                     _ => ARCH,
                                 };
+
+                                println!("{:?}", folder);
+                                println!("{:?}", get_output_path());
+                                let openconsole = folder
+                                    .join("build")
+                                    .join("native")
+                                    .join("runtimes")
+                                    .join(simplified_arch)
+                                    .join("OpenConsole.exe");
 
                                 let binaries_path = folder
                                     .join("runtimes")

--- a/build.rs
+++ b/build.rs
@@ -171,6 +171,7 @@ fn main() {
         }
 
         println!("ConPTY enabled: {}", conpty_enabled);
+        println!("Output path: {}", get_output_path().to_str().unwrap());
         // println!("ConPTY binaries found locally: {}", conpty_locally_enabled);
 
         if conpty_enabled == "1" {

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,8 @@
+# ConPTY precompiled binaries
+
+This folder can optionally contain the ConPTY precompiled binaries, in order to have async IO compatibility.
+
+## Contents
+* `conpty.dll`
+* `conpty.lib`
+* `OpenConsole.exe`

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="TerminalDependencies" value="https://pkgs.dev.azure.com/shine-oss/terminal/_packaging/TerminalDependencies/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/examples/conpty.rs
+++ b/src/examples/conpty.rs
@@ -18,13 +18,13 @@ fn main() {
             println!("{:?}", appname);
             match pty.spawn(appname, None, None, None) {
                 Ok(_) => {
-                    let mut output = pty.read(1000, false);
+                    let mut output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
@@ -35,13 +35,13 @@ fn main() {
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
@@ -57,13 +57,13 @@ fn main() {
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{}", out.to_str().unwrap()),
                         Err(err) => panic!("{:?}", err)

--- a/src/examples/winpty.rs
+++ b/src/examples/winpty.rs
@@ -18,13 +18,13 @@ fn main() {
             println!("{:?}", appname);
             match pty.spawn(appname, None, None, None) {
                 Ok(_) => {
-                    let mut output = pty.read(1000, false);
+                    let mut output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
@@ -35,13 +35,13 @@ fn main() {
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
@@ -57,13 +57,13 @@ fn main() {
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)
                     }
 
-                    output = pty.read(1000, false);
+                    output = pty.read(false);
                     match output {
                         Ok(out) => println!("{:?}", out),
                         Err(err) => panic!("{:?}", err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,155 @@ extern crate num_traits;
 pub mod pty;
 // mod pty_spawn;
 pub use pty::{PTY, PTYArgs, PTYBackend, MouseMode, AgentConfig};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+    use std::thread::sleep;
+    use std::time::Duration;
+    use std::ffi::OsString;
+
+    #[test]
+    fn test_write_performance() {
+        // Initialize PTY with default arguments
+        let mut args = PTYArgs::default();
+        args.cols = 80;
+        args.rows = 24;
+        let mut pty = PTY::new_with_backend(&args, PTYBackend::ConPTY).unwrap();
+
+        // Spawn cmd.exe
+        let cmd = OsString::from("c:\\windows\\system32\\cmd.exe");
+        pty.spawn(cmd, None, None, None).unwrap();
+
+        // Wait for process to start
+        sleep(Duration::from_millis(1000));
+
+        // Test data
+        let test_data = OsString::from("echo test\r\n");
+        let iterations = 100;
+        let mut total_time = Duration::from_secs(0);
+
+        // Perform write performance test
+        for i in 0..iterations {
+            let start = Instant::now();
+            pty.write(test_data.clone()).unwrap();
+            let duration = start.elapsed();
+            total_time += duration;
+            println!("Write {}: {:?}", i + 1, duration);
+        }
+
+        // Calculate and print statistics
+        let avg_time = total_time.as_secs_f64() / iterations as f64;
+        println!("\nWrite Performance Test Results:");
+        println!("Total time: {:?}", total_time);
+        println!("Average time per write: {:.2}ms", avg_time * 1000.0);
+        println!("Total writes: {}", iterations);
+    }
+
+    #[test]
+    fn test_read_performance() {
+        // Initialize PTY with default arguments
+        let mut args = PTYArgs::default();
+        args.cols = 80;
+        args.rows = 24;
+        let mut pty = PTY::new_with_backend(&args, PTYBackend::ConPTY).unwrap();
+
+        // Spawn cmd.exe with a command that produces continuous output
+        let cmd = OsString::from("c:\\windows\\system32\\cmd.exe");
+        pty.spawn(cmd, Some("/c echo test".into()), None, None).unwrap();
+
+        // Wait for process to start
+        sleep(Duration::from_millis(1000));
+
+        // Test parameters
+        let iterations = 100;
+        let mut total_time = Duration::from_secs(0);
+        let mut total_bytes = 0;
+        let mut successful_reads = 0;
+
+        // Perform read performance test
+        for i in 0..iterations {
+            let start = Instant::now();
+            match pty.read(false) {
+                Ok(data) => {
+                    let duration = start.elapsed();
+                    total_time += duration;
+                    total_bytes += data.len();
+                    successful_reads += 1;
+                    println!("Read {}: {:?}, bytes: {}", i + 1, duration, data.len());
+                }
+                Err(e) => {
+                    println!("Read {} failed: {:?}", i + 1, e);
+                }
+            }
+        }
+
+        // Calculate and print statistics
+        let avg_time = if successful_reads > 0 {
+            total_time.as_secs_f64() / successful_reads as f64
+        } else {
+            0.0
+        };
+        let avg_bytes = if successful_reads > 0 {
+            total_bytes as f64 / successful_reads as f64
+        } else {
+            0.0
+        };
+
+        println!("\nRead Performance Test Results:");
+        println!("Total time: {:?}", total_time);
+        println!("Average time per read: {:.2}ms", avg_time * 1000.0);
+        println!("Total bytes read: {}", total_bytes);
+        println!("Average bytes per read: {:.2}", avg_bytes);
+        println!("Successful reads: {}", successful_reads);
+    }
+
+    #[test]
+    fn test_nonblocking_read_performance() {
+        // Initialize PTY with default arguments
+        let mut args = PTYArgs::default();
+        args.cols = 80;
+        args.rows = 24;
+        
+        let mut pty = PTY::new_with_backend(&args, PTYBackend::ConPTY).unwrap();
+        pty.spawn(
+            "cmd.exe".into(),
+            Some("/c echo test".into()),
+            None,
+            None
+        ).unwrap();
+
+        // Wait for process to start
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        let start = Instant::now();
+        let mut total_bytes = 0;
+        let mut read_count = 0;
+        let mut empty_reads = 0;
+
+        // Read 100 times in non-blocking mode
+        for _ in 0..100 {
+            match pty.read(false) {
+                Ok(data) => {
+                    if data.is_empty() {
+                        empty_reads += 1;
+                    } else {
+                        total_bytes += data.len();
+                        read_count += 1;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+
+        let duration = start.elapsed();
+        println!("Non-blocking read performance test:");
+        println!("Total time: {:?}", duration);
+        println!("Average time per read: {:?}ms", duration.as_secs_f64() * 1000.0 / (read_count + empty_reads) as f64);
+        println!("Total bytes read: {}", total_bytes);
+        println!("Successful reads: {}", read_count);
+        println!("Empty reads: {}", empty_reads);
+        println!("Average bytes per successful read: {}", if read_count > 0 { total_bytes / read_count } else { 0 });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ mod tests {
         let mut args = PTYArgs::default();
         args.cols = 80;
         args.rows = 24;
-        
+
         let mut pty = PTY::new_with_backend(&args, PTYBackend::ConPTY).unwrap();
         pty.spawn(
             "cmd.exe".into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod tests {
         // Spawn cmd.exe
         let cmd = OsString::from("c:\\windows\\system32\\cmd.exe");
         pty.spawn(cmd, None, None, None).unwrap();
+        pty.write(OsString::from("\x1b[?1;0c\x1b[0;0R")).unwrap();
 
         // Wait for process to start
         sleep(Duration::from_millis(1000));
@@ -74,6 +75,7 @@ mod tests {
         // Spawn cmd.exe with a command that produces continuous output
         let cmd = OsString::from("c:\\windows\\system32\\cmd.exe");
         pty.spawn(cmd, Some("/c echo test".into()), None, None).unwrap();
+        pty.write(OsString::from("\x1b[?1;0c\x1b[0;0R")).unwrap();
 
         // Wait for process to start
         sleep(Duration::from_millis(1000));
@@ -135,6 +137,8 @@ mod tests {
             None,
             None
         ).unwrap();
+
+        pty.write(OsString::from("\x1b[?1;0c\x1b[0;0R")).unwrap();
 
         // Wait for process to start
         std::thread::sleep(std::time::Duration::from_millis(100));

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -273,7 +273,7 @@ impl PTY {
     /// # Returns
     /// The total number of characters written if the call was successful, else
     /// an [`OsString`] containing an human-readable error.
-    pub fn write(&mut self, buf: OsString) -> Result<u32, OsString> {
+    pub fn write(&self, buf: OsString) -> Result<u32, OsString> {
         self.pty.write(buf)
     }
 
@@ -312,5 +312,10 @@ impl PTY {
 	/// Wait for the process to exit/finish.
     pub fn wait_for_exit(&self) -> Result<bool, OsString> {
 		self.pty.wait_for_exit()
+	}
+
+	/// Cancel all pending reading I/O operations.
+	pub fn cancel_io(&self) -> Result<bool, OsString> {
+		self.pty.cancel_io()
 	}
 }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -242,7 +242,7 @@ impl PTY {
 		self.backend
 	}
 
-	/// Read from the process standard output.
+	/// Read all available characters from the standard output of a process.
     ///
     /// # Arguments
     /// * `blocking` - If true, wait for data to be available. If false, return immediately if no data is available.
@@ -252,7 +252,7 @@ impl PTY {
     /// * `Err(OsString)` - If EOF is reached or an error occurs
     ///
     /// # Notes
-    /// * The actual read operation happens in a background thread with a fixed buffer size
+    /// * The actual read operation happens in a background thread
     /// * The returned data is represented using a [`OsString`] since Windows operates over `u16` strings
     pub fn read(&self, blocking: bool) -> Result<OsString, OsString> {
         self.pty.read(blocking)

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -127,8 +127,15 @@ impl Default for PTYArgs {
 /// };
 ///
 /// // Initialize a winpty and a conpty pseudoterminal.
-/// let conpty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
-/// let winpty = PTY::new_with_backend(&pty_args, PTYBackend::WinPTY).unwrap();
+/// let mut conpty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
+/// let mut winpty = PTY::new_with_backend(&pty_args, PTYBackend::WinPTY).unwrap();
+///
+/// conpty.spawn(cmd.clone(), None, None, None).unwrap();
+/// winpty.spawn(cmd.clone(), None, None, None).unwrap();
+///
+/// let to_write = OsString::from("echo \"some str\"\r\n");
+/// let num_bytes1 = conpty.write(to_write.clone()).unwrap();
+/// let num_bytes2 = winpty.write(to_write.clone()).unwrap();
 /// ```
 pub struct PTY {
 	 /// Backend used by the current pseudoterminal, must be one of [`self::PTYBackend`].
@@ -266,7 +273,7 @@ impl PTY {
     /// # Returns
     /// The total number of characters written if the call was successful, else
     /// an [`OsString`] containing an human-readable error.
-    pub fn write(&self, buf: OsString) -> Result<u32, OsString> {
+    pub fn write(&mut self, buf: OsString) -> Result<u32, OsString> {
         self.pty.write(buf)
     }
 

--- a/src/pty/base.rs
+++ b/src/pty/base.rs
@@ -463,7 +463,7 @@ impl PTYProcess {
                 if let Ok(Some(process)) = process_result {
                     reader_ready.store(true, Ordering::Release);
                     while reader_alive_rx
-                        .recv_timeout(Duration::from_micros(100))
+                        .try_recv()
                         .unwrap_or(true)
                     {
                         if !is_eof(process.into(), conout.into()).unwrap() {
@@ -627,7 +627,7 @@ impl PTYProcess {
                 Ok(Some(bytes)) => bytes,
                 Err(_) => Ok(OsString::new()),
             },
-            false => match self.reader_out_rx.recv_timeout(Duration::from_micros(200)) {
+            false => match self.reader_out_rx.try_recv() {
                 Ok(None) => Err(OsString::from("Standard out reached EOF")),
                 Ok(Some(bytes)) => bytes,
                 Err(_) => Ok(OsString::new()),

--- a/src/pty/conpty.rs
+++ b/src/pty/conpty.rs
@@ -5,6 +5,10 @@
 // Actual implementation if winpty is available
 #[cfg(feature="conpty")]
 mod pty_impl;
+mod calls;
+
+#[cfg(all(feature="conpty", feature="conpty_local"))]
+mod bindings;
 
 #[cfg(feature="conpty")]
 pub use pty_impl::ConPTY;

--- a/src/pty/conpty/bindings.rs
+++ b/src/pty/conpty/bindings.rs
@@ -1,0 +1,83 @@
+use std::ffi::c_void;
+/// ConPTY bindings
+use std::os::windows::raw::HANDLE;
+use windows::Win32::System::Console::COORD;
+
+
+extern "C" {
+    /// Creates a "Pseudo-console" (conpty) with dimensions (in characters)
+    ///      provided by the `size` parameter. The caller should provide two handles:
+    /// - `hInput` is used for writing input to the pty, encoded as UTF-8 and VT sequences.
+    /// - `hOutput` is used for reading the output of the pty, encoded as UTF-8 and VT sequences.
+    /// Once the call completes, `phPty` will receive a token value to identify this
+    ///      conpty object. This value should be used in conjunction with the other
+    ///      Pseudoconsole API's.
+    /// `dwFlags` is used to specify optional behavior to the created pseudoconsole.
+    /// The flags can be combinations of the following values:
+    ///  INHERIT_CURSOR: This will cause the created conpty to attempt to inherit the
+    ///      cursor position of the parent terminal application. This can be useful
+    ///      for applications like `ssh`, where ssh (currently running in a terminal)
+    ///      might want to create a pseudoterminal session for an child application
+    ///      and the child inherit the cursor position of ssh.
+    ///      The created conpty will immediately emit a "Device Status Request" VT
+    ///      sequence to hOutput, that should be replied to on hInput in the format
+    ///      "\x1b[<r>;<c>R", where `<r>` is the row and `<c>` is the column of the
+    ///      cursor position.
+    ///      This requires a cooperating terminal application - if a caller does not
+    ///      reply to this message, the conpty will not process any input until it
+    ///      does. Most *nix terminals and the Windows Console (after Windows 10
+    ///      Anniversary Update) will be able to handle such a message.
+    pub fn ConptyCreatePseudoConsole(
+        size: COORD,
+        hInput: HANDLE,
+        hOutput: HANDLE,
+        dwFlags: u32,
+        hPC: *mut c_void,
+    ) -> i32;
+
+    /// Resizes the given conpty to the specified size, in characters.
+    pub fn ConptyResizePseudoConsole(hPC: *mut c_void, size: COORD) -> i32;
+
+    /// - Clear the contents of the conpty buffer, leaving the cursor row at the top
+    ///   of the viewport.
+    /// - This is used exclusively by ConPTY to support GH#1193, GH#1882. This allows
+    ///   a terminal to clear the contents of the ConPTY buffer, which is important
+    ///   if the user would like to be able to clear the terminal-side buffer.
+    pub fn ConptyClearPseudoConsole(hPC: *mut c_void) -> i32;
+
+    /// - Tell the ConPTY about the state of the hosting window. This should be used
+    ///   to keep ConPTY's internal HWND state in sync with the state of whatever the
+    ///   hosting window is.
+    /// - For more information, refer to GH#12515.
+    pub fn ConptyShowHidePseudoConsole(hPC: *mut c_void, show: bool) -> i32;
+
+    /// - Sends a message to the pseudoconsole informing it that it should use the
+    ///   given window handle as the owner for the conpty's pseudo window. This
+    ///   allows the response given to GetConsoleWindow() to be a HWND that's owned
+    ///   by the actual hosting terminal's HWND.
+    /// - Used to support GH#2988
+    pub fn ConptyReparentPseudoConsole(hPC: *mut c_void, newParent: *mut c_void) -> i32;
+
+    /// The \Reference handle ensures that conhost keeps running by keeping the ConDrv server pipe open.
+    /// After you've finished setting up your PTY via PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, this method may be called
+    /// to release that handle, allowing conhost to shut down automatically once the last client has disconnected.
+    /// You'll know when this happens, because a ReadFile() on the output pipe will return ERROR_BROKEN_PIPE.
+    pub fn ConptyReleasePseudoConsole(hPC: *mut c_void) -> i32;
+
+    /// Closes the conpty and all associated state.
+    /// Client applications attached to the conpty will also behave as though the
+    ///      console window they were running in was closed.
+    /// This can fail if the conhost hosting the pseudoconsole failed to be
+    ///      terminated, or if the pseudoconsole was already terminated.
+    /// Waits for conhost/OpenConsole to exit first.
+    pub fn ConptyClosePseudoConsole(hPC: *mut c_void) -> i32;
+
+    // Packs loose handle information for an inbound ConPTY
+    //  session into the same HPCON as a created session.
+    pub fn ConptyPackPseudoConsole(
+        hServerProcess: HANDLE,
+        hRef: HANDLE,
+        hSignal: HANDLE,
+        phPC: *mut c_void,
+    ) -> i32;
+}

--- a/src/pty/conpty/calls.rs
+++ b/src/pty/conpty/calls.rs
@@ -1,0 +1,81 @@
+// #[cfg(all(feature="conpty", feature="conpty_local"))]
+// mod bindings;
+#![allow(non_snake_case)]
+
+use windows::core::{Error, Result, HRESULT};
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::System::Console::{COORD, HPCON};
+
+use std::ffi::c_void;
+use std::mem::MaybeUninit;
+use std::os::windows::raw;
+
+#[cfg(all(feature = "conpty", not(feature = "conpty_local")))]
+pub use windows::Win32::System::Console::{CreatePseudoConsole, ResizePseudoConsole, ClosePseudoConsole};
+
+#[cfg(all(feature = "conpty", feature = "conpty_local"))]
+use super::bindings::{
+    ConptyClearPseudoConsole, ConptyClosePseudoConsole, ConptyCreatePseudoConsole,
+    ConptyResizePseudoConsole,
+};
+
+#[cfg(all(feature = "conpty", feature = "conpty_local"))]
+pub unsafe fn CreatePseudoConsole(
+    size: COORD,
+    hInput: HANDLE,
+    hOutput: HANDLE,
+    dwFlags: u32,
+) -> Result<HPCON> {
+    let mut console_handle_uninit = MaybeUninit::<HPCON>::uninit();
+    let result_code = ConptyCreatePseudoConsole(
+        size,
+        hInput.0 as raw::HANDLE,
+        hOutput.0 as raw::HANDLE,
+        dwFlags,
+        console_handle_uninit.as_mut_ptr() as *mut c_void,
+    );
+
+    let result = HRESULT::from_nt(result_code);
+    if result.is_err() {
+        Err(Error::from_hresult(result))
+    } else {
+        let console_handle = console_handle_uninit.assume_init();
+        Ok(console_handle)
+    }
+}
+
+#[cfg(all(feature = "conpty", feature = "conpty_local"))]
+pub unsafe fn ResizePseudoConsole(hPC: HPCON, size: COORD) -> Result<()> {
+    let result_code = ConptyResizePseudoConsole(hPC.0 as *mut c_void, size);
+
+    let result = HRESULT::from_nt(result_code);
+    if result.is_err() {
+        Err(Error::from_hresult(result))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "conpty", feature = "conpty_local"))]
+pub unsafe fn ClearPseudoConsole(hPC: HPCON) -> Result<()> {
+    let result_code = ConptyClearPseudoConsole(hPC.0 as *mut c_void);
+
+    let result = HRESULT::from_nt(result_code);
+    if result.is_err() {
+        Err(Error::from_hresult(result))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "conpty", feature = "conpty_local"))]
+pub unsafe fn ClosePseudoConsole(hPC: HPCON) -> Result<()> {
+    let result_code = ConptyClosePseudoConsole(hPC.0 as *mut c_void);
+
+    let result = HRESULT::from_nt(result_code);
+    if result.is_err() {
+        Err(Error::from_hresult(result))
+    } else {
+        Ok(())
+    }
+}

--- a/src/pty/conpty/calls.rs
+++ b/src/pty/conpty/calls.rs
@@ -16,7 +16,7 @@ pub use windows::Win32::System::Console::{CreatePseudoConsole, ResizePseudoConso
 #[cfg(all(feature = "conpty", feature = "conpty_local"))]
 use super::bindings::{
     ConptyClearPseudoConsole, ConptyClosePseudoConsole, ConptyCreatePseudoConsole,
-    ConptyResizePseudoConsole,
+    ConptyResizePseudoConsole, ConptyShowHidePseudoConsole,
 };
 
 #[cfg(all(feature = "conpty", feature = "conpty_local"))]
@@ -71,6 +71,18 @@ pub unsafe fn ClearPseudoConsole(hPC: HPCON) -> Result<()> {
 #[cfg(all(feature = "conpty", feature = "conpty_local"))]
 pub unsafe fn ClosePseudoConsole(hPC: HPCON) -> Result<()> {
     let result_code = ConptyClosePseudoConsole(hPC.0 as *mut c_void);
+
+    let result = HRESULT::from_nt(result_code);
+    if result.is_err() {
+        Err(Error::from_hresult(result))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "conpty", feature = "conpty_local"))]
+pub unsafe fn ShowHidePseudoConsole(hPC: HPCON, show: bool) -> Result<()> {
+    let result_code = ConptyShowHidePseudoConsole(hPC.0 as *mut c_void, show);
 
     let result = HRESULT::from_nt(result_code);
     if result.is_err() {

--- a/src/pty/conpty/default_impl.rs
+++ b/src/pty/conpty/default_impl.rs
@@ -22,7 +22,7 @@ impl PTYImpl for ConPTY {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 
-    fn write(&mut self, _buf: OsString) -> Result<u32, OsString> {
+    fn write(&self, _buf: OsString) -> Result<u32, OsString> {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 
@@ -48,5 +48,9 @@ impl PTYImpl for ConPTY {
 
     fn wait_for_exit(&self) -> Result<bool, OsString> {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
+    }
+
+    fn cancel_io(&self) -> Result<bool, OsString> {
+        Err(OsString::from("winpty_rs was compiled without ConPTY enabled"))
     }
 }

--- a/src/pty/conpty/default_impl.rs
+++ b/src/pty/conpty/default_impl.rs
@@ -1,4 +1,3 @@
-
 use std::ffi::OsString;
 
 // Default implementation if winpty is not available
@@ -19,7 +18,7 @@ impl PTYImpl for ConPTY {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 
-    fn read(&self, _length: u32, _blocking: bool) -> Result<OsString, OsString> {
+    fn read(&self, _blocking: bool) -> Result<OsString, OsString> {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 

--- a/src/pty/conpty/default_impl.rs
+++ b/src/pty/conpty/default_impl.rs
@@ -22,7 +22,7 @@ impl PTYImpl for ConPTY {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 
-    fn write(&self, _buf: OsString) -> Result<u32, OsString> {
+    fn write(&mut self, _buf: OsString) -> Result<u32, OsString> {
         Err(OsString::from("pty_rs was compiled without ConPTY enabled"))
     }
 

--- a/src/pty/conpty/pty_impl.rs
+++ b/src/pty/conpty/pty_impl.rs
@@ -563,7 +563,7 @@ impl PTYImpl for ConPTY {
         self.process.read(blocking)
     }
 
-    fn write(&mut self, buf: OsString) -> Result<u32, OsString> {
+    fn write(&self, buf: OsString) -> Result<u32, OsString> {
         self.process.write(buf)
     }
 
@@ -589,6 +589,10 @@ impl PTYImpl for ConPTY {
 
     fn wait_for_exit(&self) -> Result<bool, OsString> {
         self.process.wait_for_exit()
+    }
+
+    fn cancel_io(&self) -> Result<bool, OsString> {
+        self.process.cancel_io()
     }
 }
 

--- a/src/pty/conpty/pty_impl.rs
+++ b/src/pty/conpty/pty_impl.rs
@@ -41,7 +41,7 @@ use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 use std::{mem, ptr, thread};
 
-use super::calls::{ClosePseudoConsole, CreatePseudoConsole, ResizePseudoConsole};
+use super::calls::{ClosePseudoConsole, CreatePseudoConsole, ResizePseudoConsole, ShowHidePseudoConsole};
 use crate::pty::PTYArgs;
 use crate::pty::{PTYImpl, PTYProcess};
 
@@ -407,6 +407,8 @@ impl PTYImpl for ConPTY {
                     return Err(string);
                 }
             };
+
+            let _ = ShowHidePseudoConsole(pty_handle, false);
 
             // let _ = CloseHandle(input_read_side);
             // let _ = CloseHandle(output_write_side);

--- a/src/pty/conpty/pty_impl.rs
+++ b/src/pty/conpty/pty_impl.rs
@@ -331,8 +331,8 @@ impl PTYImpl for ConPTY {
         }
     }
 
-    fn read(&self, length: u32, blocking: bool) -> Result<OsString, OsString> {
-        self.process.read(length, blocking)
+    fn read(&self, blocking: bool) -> Result<OsString, OsString> {
+        self.process.read(blocking)
     }
 
     fn write(&self, buf: OsString) -> Result<u32, OsString> {

--- a/src/pty/winpty.rs
+++ b/src/pty/winpty.rs
@@ -24,12 +24,12 @@ mod default_impl;
 pub use default_impl::WinPTY;
 
 ///  Mouse capture settings for the winpty backend.
-#[derive(Primitive)]
+#[derive(Primitive, Clone, Debug)]
 #[allow(non_camel_case_types)]
 pub enum MouseMode {
     /// QuickEdit mode is initially disabled, and the agent does not send mouse
     /// mode sequences to the terminal.  If it receives mouse input, though, it
-    // still writes MOUSE_EVENT_RECORD values into CONIN.
+    /// still writes MOUSE_EVENT_RECORD values into CONIN.
     WINPTY_MOUSE_MODE_NONE = 0,
 
     /// QuickEdit mode is initially enabled.  As CONIN enters or leaves mouse
@@ -46,6 +46,7 @@ pub enum MouseMode {
 
 bitflags! {
     /// General configuration settings for the winpty backend.
+    #[derive(Clone, Debug)]
     pub struct AgentConfig: u64 {
         /// Create a new screen buffer (connected to the "conerr" terminal pipe) and
         /// pass it to child processes as the STDERR handle.  This flag also prevents

--- a/src/pty/winpty/default_impl.rs
+++ b/src/pty/winpty/default_impl.rs
@@ -1,4 +1,3 @@
-
 use std::ffi::OsString;
 use crate::pty::{PTYArgs, PTYImpl};
 
@@ -17,7 +16,7 @@ impl PTYImpl for WinPTY {
         Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
     }
 
-    fn read(&self, _length: u32, _blocking: bool) -> Result<OsString, OsString> {
+    fn read(&self, _blocking: bool) -> Result<OsString, OsString> {
         Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
     }
 

--- a/src/pty/winpty/default_impl.rs
+++ b/src/pty/winpty/default_impl.rs
@@ -20,7 +20,7 @@ impl PTYImpl for WinPTY {
         Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
     }
 
-    fn write(&mut self, _buf: OsString) -> Result<u32, OsString> {
+    fn write(&self, _buf: OsString) -> Result<u32, OsString> {
         Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
     }
 
@@ -45,6 +45,10 @@ impl PTYImpl for WinPTY {
     }
 
     fn wait_for_exit(&self) -> Result<bool, OsString> {
+        Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
+    }
+
+    fn cancel_io(&self) -> Result<bool, OsString> {
         Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
     }
 }

--- a/src/pty/winpty/default_impl.rs
+++ b/src/pty/winpty/default_impl.rs
@@ -20,7 +20,7 @@ impl PTYImpl for WinPTY {
         Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
     }
 
-    fn write(&self, _buf: OsString) -> Result<u32, OsString> {
+    fn write(&mut self, _buf: OsString) -> Result<u32, OsString> {
         Err(OsString::from("winpty_rs was compiled without WinPTY enabled"))
     }
 

--- a/src/pty/winpty/pty_impl.rs
+++ b/src/pty/winpty/pty_impl.rs
@@ -1,7 +1,7 @@
 /// Actual WinPTY backend implementation.
 
-use windows::Win32::Foundation::{HANDLE};
-use windows::core::{PCWSTR};
+use windows::Win32::Foundation::HANDLE;
+use windows::core::PCWSTR;
 use windows::Win32::Storage::FileSystem::{
     CreateFileW, FILE_GENERIC_READ, FILE_SHARE_NONE,
     OPEN_EXISTING, FILE_GENERIC_WRITE,
@@ -279,8 +279,8 @@ impl PTYImpl for WinPTY {
         self.ptr.set_size(cols, rows)
     }
 
-    fn read(&self, length: u32, blocking: bool) -> Result<OsString, OsString> {
-        self.process.read(length, blocking)
+    fn read(&self, blocking: bool) -> Result<OsString, OsString> {
+        self.process.read(blocking)
     }
 
     fn write(&self, buf: OsString) -> Result<u32, OsString> {

--- a/src/pty/winpty/pty_impl.rs
+++ b/src/pty/winpty/pty_impl.rs
@@ -283,7 +283,7 @@ impl PTYImpl for WinPTY {
         self.process.read(blocking)
     }
 
-    fn write(&mut self, buf: OsString) -> Result<u32, OsString> {
+    fn write(&self, buf: OsString) -> Result<u32, OsString> {
         self.process.write(buf)
     }
 
@@ -309,6 +309,10 @@ impl PTYImpl for WinPTY {
 
     fn wait_for_exit(&self) -> Result<bool, OsString> {
         self.process.wait_for_exit()
+    }
+
+    fn cancel_io(&self) -> Result<bool, OsString> {
+        self.process.cancel_io()
     }
 }
 

--- a/src/pty/winpty/pty_impl.rs
+++ b/src/pty/winpty/pty_impl.rs
@@ -221,7 +221,7 @@ impl PTYImpl for WinPTY {
             let conin = conin_res.unwrap();
             let conout = conout_res.unwrap();
 
-            let process = PTYProcess::new(conin.into(), conout.into(), false, false);
+            let process = PTYProcess::new(conin.into(), conout.into(), false, false, None);
             Ok(Box::new(WinPTY { ptr: pty_ptr, process }) as Box<dyn PTYImpl>)
         }
     }

--- a/src/pty/winpty/pty_impl.rs
+++ b/src/pty/winpty/pty_impl.rs
@@ -221,7 +221,7 @@ impl PTYImpl for WinPTY {
             let conin = conin_res.unwrap();
             let conout = conout_res.unwrap();
 
-            let process = PTYProcess::new(conin.into(), conout.into(), false);
+            let process = PTYProcess::new(conin.into(), conout.into(), false, false);
             Ok(Box::new(WinPTY { ptr: pty_ptr, process }) as Box<dyn PTYImpl>)
         }
     }
@@ -283,7 +283,7 @@ impl PTYImpl for WinPTY {
         self.process.read(blocking)
     }
 
-    fn write(&self, buf: OsString) -> Result<u32, OsString> {
+    fn write(&mut self, buf: OsString) -> Result<u32, OsString> {
         self.process.write(buf)
     }
 

--- a/tests/conpty.rs
+++ b/tests/conpty.rs
@@ -22,6 +22,7 @@ fn spawn_conpty() {
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
     let mut pty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
     pty.spawn(appname, None, None, None).unwrap();
+    pty.write(OsString::from("\x1b[?1;0c\x1b[0;0R")).unwrap();
 
     let ten_millis = time::Duration::from_millis(10);
     thread::sleep(ten_millis);
@@ -40,6 +41,7 @@ fn read_write_conpty() {
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
     let mut pty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
     pty.spawn(appname, None, None, None).unwrap();
+    pty.write(OsString::from("\x1b[?1;0c\x1b[0;0R")).unwrap();
 
     let re_pattern: &str = r".*Microsoft Windows.*";
     let regex = Regex::new(re_pattern).unwrap();

--- a/tests/conpty.rs
+++ b/tests/conpty.rs
@@ -101,7 +101,9 @@ fn set_size_conpty() {
     let mut pty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
     pty.spawn(appname, None, None, None).unwrap();
 
-    sleep(Duration::from_millis(5000));
+    pty.write(OsString::from("\x1b[?1;0c\x1b[0;0R")).unwrap();
+
+    // sleep(Duration::from_millis(5000));
 
     pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into()).unwrap();
     let regex = Regex::new(r".*Width.*").unwrap();
@@ -151,7 +153,7 @@ fn set_size_conpty() {
         pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into()).unwrap();
         let regex = Regex::new(r".*Width.*").unwrap();
         let mut output_str = "";
-        let mut out = OsString::new();;
+        let mut out = OsString::new();
 
         while !regex.is_match(output_str) {
             out = pty.read(false).unwrap();
@@ -196,8 +198,9 @@ fn is_alive_exitstatus_conpty() {
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
     let mut pty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
     pty.spawn(appname, None, None, None).unwrap();
+    pty.write(OsString::from("\x1b[?1;0c\x1b[0;0R")).unwrap();
 
-    sleep(Duration::from_millis(5000));
+    // sleep(Duration::from_millis(5000));
 
     pty.write("echo wait\r\n".into()).unwrap();
     assert!(pty.is_alive().unwrap());
@@ -224,8 +227,9 @@ fn wait_for_exit() {
     let appname = OsString::from("C:\\Windows\\System32\\cmd.exe");
     let mut pty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
     pty.spawn(appname, None, None, None).unwrap();
+    pty.write(OsString::from("\x1b[?1;0c\x1b[0;0R")).unwrap();
 
-    sleep(Duration::from_millis(5000));
+    // sleep(Duration::from_millis(5000));
 
     pty.write("echo wait\r\n".into()).unwrap();
     assert!(pty.is_alive().unwrap());
@@ -252,7 +256,8 @@ fn check_eof_output() {
     let mut pty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
     pty.spawn(appname, Some(OsString::from("-c \"print(\';\'.join([str(i) for i in range(0, 2048)]))\"")), None, None).unwrap();
     assert!(pty.is_alive().unwrap());
-    sleep(Duration::from_millis(5000));
+    pty.write(OsString::from("\x1b[?1;0c\x1b[0;0R")).unwrap();
+    // sleep(Duration::from_millis(5000));
 
     let mut collect_vec: Vec<String> = Vec::new();
     let mut valid = true;

--- a/tests/conpty.rs
+++ b/tests/conpty.rs
@@ -106,7 +106,7 @@ fn set_size_conpty() {
     pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into()).unwrap();
     let regex = Regex::new(r".*Width.*").unwrap();
     let mut output_str = "";
-    let mut out: OsString;
+    let mut out = OsString::new();
 
     while !regex.is_match(output_str) {
         out = pty.read(false).unwrap();
@@ -114,8 +114,9 @@ fn set_size_conpty() {
     }
 
     let mut collect_vec: Vec<String> = Vec::new();
-    let num_regex = Regex::new(r"\s+-*\s*-*\s+(\d+)\s+(\d+).*").unwrap();
-    let mut collected_str = String::new();
+    let num_regex = Regex::new(r".*\s+-*\s*-*\s+(\d+)\s+(\d+).*").unwrap();
+    let mut collected_str = out.into_string().unwrap();
+    collect_vec.push(collected_str.clone());
 
     while !num_regex.is_match(&collected_str) {
         let out = pty.read(false).unwrap();
@@ -150,7 +151,7 @@ fn set_size_conpty() {
         pty.write("powershell -command \"&{(get-host).ui.rawui.WindowSize;}\"\r\n".into()).unwrap();
         let regex = Regex::new(r".*Width.*").unwrap();
         let mut output_str = "";
-        let mut out: OsString;
+        let mut out = OsString::new();;
 
         while !regex.is_match(output_str) {
             out = pty.read(false).unwrap();
@@ -160,8 +161,9 @@ fn set_size_conpty() {
         println!("{:?}", output_str);
 
         let mut collect_vec: Vec<String> = Vec::new();
-        let num_regex = Regex::new(r"\s+-*\s*-*\s+(\d+)\s+(\d+).*").unwrap();
-        let mut collected_str = String::new();
+        let num_regex = Regex::new(r".*\s+-*\s*-*\s+(\d+)\s+(\d+).*").unwrap();
+        let mut collected_str = out.into_string().unwrap();
+        collect_vec.push(collected_str.clone());
 
         while !num_regex.is_match(&collected_str) {
             let out = pty.read(false).unwrap();

--- a/tests/conpty.rs
+++ b/tests/conpty.rs
@@ -46,7 +46,7 @@ fn read_write_conpty() {
     let mut tries = 0;
 
     while !regex.is_match(output_str) && tries < 5 {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
         println!("{:?}", output_str);
         tries += 1;
@@ -59,7 +59,7 @@ fn read_write_conpty() {
 
     output_str = "";
     while !echo_regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
         println!("{:?}", output_str);
     }
@@ -71,7 +71,7 @@ fn read_write_conpty() {
 
     output_str = "";
     while !out_regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
         println!("{:?}", output_str);
     }
@@ -101,7 +101,7 @@ fn set_size_conpty() {
     let mut out: OsString;
 
     while !regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -140,7 +140,7 @@ fn set_size_conpty() {
         let mut out: OsString;
 
         while !regex.is_match(output_str) {
-            out = pty.read(1000, false).unwrap();
+            out = pty.read(false).unwrap();
             output_str = out.to_str().unwrap();
         }
 
@@ -234,7 +234,7 @@ fn check_eof_output() {
     let mut valid = true;
 
     while valid {
-        let out_wrapped = pty.read(1000, false);
+        let out_wrapped = pty.read(false);
         match out_wrapped {
             Ok(out) => collect_vec.push(out.into_string().unwrap()),
             Err(_) => {valid = false;}

--- a/tests/winpty.rs
+++ b/tests/winpty.rs
@@ -40,7 +40,7 @@ fn read_write_winpty() {
     let mut out: OsString;
 
     while !regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -51,7 +51,7 @@ fn read_write_winpty() {
 
     output_str = "";
     while !echo_regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -62,7 +62,7 @@ fn read_write_winpty() {
 
     output_str = "";
     while !out_regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -90,7 +90,7 @@ fn set_size_winpty() {
     let mut out: OsString;
 
     while !regex.is_match(output_str) {
-        out = pty.read(1000, false).unwrap();
+        out = pty.read(false).unwrap();
         output_str = out.to_str().unwrap();
     }
 
@@ -123,7 +123,7 @@ fn set_size_winpty() {
         let mut out: OsString;
 
         while !regex.is_match(output_str) {
-            out = pty.read(1000, false).unwrap();
+            out = pty.read(false).unwrap();
             output_str = out.to_str().unwrap();
         }
 


### PR DESCRIPTION
Closes #93 
Fixes https://github.com/andfoy/pywinpty/issues/490
Fixes https://github.com/andfoy/pywinpty/issues/484

This PR replaces synchronous pipes in ConPTY by asynchronous ones (via https://github.com/microsoft/terminal/pull/17510). By doing so, dependency on local Windows calls are replaced by linking against newer ConPTY binaries (provided by Microsoft using NuGet packages). 

It also switches the `windows-rs` dependency to a local fork that exposes the `NtCreateNamedPipeFile` Windows API, which is required to spawn the required pipes, which should be replaced back by the upstream one once https://github.com/microsoft/wdkmetadata/issues/91 and https://github.com/microsoft/terminal/pull/17510 are fixed by MS.