### PR TITLE
Improve EOF testing

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -173,16 +173,16 @@ fn main() {
         println!("Windows build number: {:?}", build_version);
 
         // let conpty_enabled;
-        let kernel32_res = unsafe { GetModuleHandleW(&HSTRING::from("kernel32.dll")) };
-        let kernel32 = kernel32_res.unwrap();
+        // let kernel32_res = unsafe { GetModuleHandleW(&HSTRING::from("kernel32.dll")) };
+        // let kernel32 = kernel32_res.unwrap();
 
-        let conpty = unsafe { GetProcAddress(kernel32, "CreatePseudoConsole".into_pcstr()) };
-        match conpty {
-            Some(_) => {
+        // let conpty = unsafe { GetProcAddress(kernel32, "CreatePseudoConsole".into_pcstr()) };
+        match major_version >= 10 && build_version >= 2004 {
+            true => {
                 conpty_enabled = "1";
                 println!("cargo:rustc-cfg=feature=\"conpty\"")
             }
-            None => {
+            false => {
                 conpty_enabled = "0";
             }
         }


### PR DESCRIPTION
Checking for the process aliveness, if there is input in the reading queue as well if the reading process is still alive is required to mark a process as reaching EOF