### PR TITLE
Update build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -242,6 +242,7 @@ fn main() {
                                 let simplified_arch = match ARCH {
                                     "x86_64" => "x64",
                                     "arm" => "arm64",
+                                    "aarch64" => "arm64",
                                     _ => ARCH,
                                 };
 


### PR DESCRIPTION
ARCH is "aarch64" on a Snapdragon X Elite CPU but can still resolve to arm64 for ConPTY