### PR TITLE
Fix PTY drop logic error (#116)

### DIFF
--- a/src/pty/base.rs
+++ b/src/pty/base.rs
@@ -460,8 +460,8 @@ impl PTYProcess {
 
             let reader_thread = thread::spawn(move || {
                 let process_result = reader_process_rx.recv();
+                reader_ready.store(true, Ordering::Release);
                 if let Ok(Some(process)) = process_result {
-                    reader_ready.store(true, Ordering::Release);
                     let mut alive = reader_alive_rx
                         .try_recv()
                         .unwrap_or(true);
@@ -484,9 +484,8 @@ impl PTYProcess {
                             alive = false;
                         }
                     }
-                    spinlock_clone.store(false, Ordering::Release);
                 }
-
+                spinlock_clone.store(false, Ordering::Release);
                 drop(reader_process_rx);
                 drop(reader_alive_rx);
                 drop(reader_out_tx);
@@ -543,8 +542,8 @@ impl PTYProcess {
                 }
 
                 let process_result = reader_process_rx.recv();
+                reader_ready.store(true, Ordering::Release);
                 if let Ok(Some(process)) = process_result {
-                    reader_ready.store(true, Ordering::Release);
                     let _ = reader_process_2_tx.send(process);
                     let mut alive = true;
                     while alive {
@@ -563,9 +562,8 @@ impl PTYProcess {
                     unsafe {
                         let _ = CloseHandle(read_overlapped.hEvent);
                     }
-                    spinlock_clone.store(false, Ordering::Release);
                 }
-
+                spinlock_clone.store(false, Ordering::Release);
                 drop(reader_process_rx);
                 drop(reader_alive_rx);
                 drop(reader_out_tx);

--- a/src/pty/conpty/pty_impl.rs
+++ b/src/pty/conpty/pty_impl.rs
@@ -431,21 +431,25 @@ impl PTYImpl for ConPTY {
             let hpcon_clone = Arc::clone(&hpcon_mutex);
 
             let cleanup_thread = thread::spawn(move || {
-                let (_hthread_ptr, _hprocess_ptr, _startup_ptr, hpcon_ptr, console_allocated) =
-                    release_info_rx.recv().unwrap();
-                let clean = cleanup_rx.recv().unwrap();
-                if clean {
-                    let mut hpcon_guard = hpcon_clone.lock().unwrap();
-                    if hpcon_guard.1 {
-                        cleanup(
-                            // LocalHandle(hthread_ptr as *mut c_void),
-                            // LocalHandle(hprocess_ptr as *mut c_void),
-                            // LPPROC_THREAD_ATTRIBUTE_LIST(startup_ptr as *mut c_void),
-                            hpcon_guard.0.0,
-                            console_allocated,
-                        );
-                        *hpcon_guard = (hpcon_guard.0, false);
-                    }
+                match release_info_rx.recv() {
+                    Ok((_hthread_ptr, _hprocess_ptr, _startup_ptr, hpcon_ptr, console_allocated))=>{
+                        if let Ok(clean) = cleanup_rx.recv(){
+                            if clean {
+                                let mut hpcon_guard = hpcon_clone.lock().unwrap();
+                                if hpcon_guard.1 {
+                                    cleanup(
+                                        // LocalHandle(hthread_ptr as *mut c_void),
+                                        // LocalHandle(hprocess_ptr as *mut c_void),
+                                        // LPPROC_THREAD_ATTRIBUTE_LIST(startup_ptr as *mut c_void),
+                                        hpcon_guard.0.0,
+                                        console_allocated,
+                                    );
+                                    *hpcon_guard = (hpcon_guard.0, false);
+                                }
+                            }
+                        }
+                    },
+                    Err(_)=>{}
                 }
                 drop(cleanup_rx);
                 drop(release_info_rx);

--- a/tests/conpty.rs
+++ b/tests/conpty.rs
@@ -288,3 +288,46 @@ fn check_eof_output() {
     let _ = pty.wait_for_exit();
 
 }
+
+#[test]
+fn drop_timing_conpty() {
+    use std::sync::mpsc::channel;
+    use std::thread;
+    use std::time::{ Duration, Instant };
+
+    let pty_args = PTYArgs {
+        cols: 80,
+        rows: 25,
+        mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
+        timeout: 10000,
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
+    };
+
+    let pty = PTY::new_with_backend(&pty_args, PTYBackend::ConPTY).unwrap();
+    let (tx, rx) = channel::<Instant>();
+
+    thread::spawn(move || {
+        let start = Instant::now();
+        drop(pty);
+        let _ = tx.send(start);
+    });
+
+    let timeout = Duration::from_secs(2);
+    match rx.recv_timeout(timeout) {
+        Ok(start) => {
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed.as_millis() < 1000,
+                "drop took {}ms, expected < 1000ms",
+                elapsed.as_millis()
+            );
+            println!("drop completed in {}ms", elapsed.as_millis());
+        }
+        Err(_) => {
+            panic!(
+                "drop timed out after {} seconds, possible infinite loop detected",
+                timeout.as_secs()
+            );
+        }
+    }
+}

--- a/tests/winpty.rs
+++ b/tests/winpty.rs
@@ -197,3 +197,46 @@ fn wait_for_exit() {
     assert!(!pty.is_alive().unwrap());
     assert_eq!(pty.get_exitstatus().unwrap(), Some(0))
 }
+
+#[test]
+fn drop_timing_winpty() {
+    use std::sync::mpsc::channel;
+    use std::thread;
+    use std::time::{ Duration, Instant };
+
+    let pty_args = PTYArgs {
+        cols: 80,
+        rows: 25,
+        mouse_mode: MouseMode::WINPTY_MOUSE_MODE_NONE,
+        timeout: 10000,
+        agent_config: AgentConfig::WINPTY_FLAG_COLOR_ESCAPES,
+    };
+
+    let pty = PTY::new_with_backend(&pty_args, PTYBackend::WinPTY).unwrap();
+    let (tx, rx) = channel::<Instant>();
+
+    thread::spawn(move || {
+        let start = Instant::now();
+        drop(pty);
+        let _ = tx.send(start);
+    });
+
+    let timeout = Duration::from_secs(2);
+    match rx.recv_timeout(timeout) {
+        Ok(start) => {
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed.as_millis() < 1000,
+                "drop took {}ms, expected < 1000ms",
+                elapsed.as_millis()
+            );
+            println!("drop completed in {}ms", elapsed.as_millis());
+        }
+        Err(_) => {
+            panic!(
+                "drop timed out after {} seconds, possible infinite loop detected",
+                timeout.as_secs()
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the issue reported in #116.

**Main changes:**

1. **Fixed a logic bug in `src/pty/base.rs`:** The original code assumed that a successful `spawn` would always occur before `drop`. 
However, it's highly possible that the object gets dropped without ever calling `spawn`, or gets dropped after a failed `spawn`. 
By tracing the references of `reader_process_tx`, we can see that `reader_process_rx` will only receive `None` upon `drop`, and a valid `process` only after a successful `spawn`. Therefore, setting `reader_ready` and `spinlock_clone` outside the `if let Ok(Some(process)) = process_result` block is sufficient. This ensures that when the `reader_thread` exits, `reader_ready` is always `true` and `spinlock_clone` is always `false`, allowing `drop()` to complete smoothly.

2. **Improved robustness in `src/pty/conpty/pty_impl.rs`:** After the object is dropped, `release_info_rx` and `cleanup_rx` may fail. The original code used `unwrap()` directly, which would cause a panic. I've replaced this with `match` to gracefully handle channel closure and prevent panics.

3. **Added a unit test for the drop behavior to prevent regression of #116 in future versions:**
   - The test passes if `drop` completes within 1 second.
   - If `drop` doesn't finish within 2 seconds, the test will forcefully panic to prevent the test suite from hanging.

All unit tests pass, and I've also manually performed end-to-end testing. Based on this version, the built `pywinpty` no longer exhibits the issue.

> If possible, I'd love to see a new release as soon as possible. This bug has a pretty significant impact on programs that heavily rely on `pywinpty` 😵‍💫
