### PR TITLE
Remove alive_thread and cleanup_thread, match Terminal teardown pattern

### DIFF
--- a/src/pty/base.rs
+++ b/src/pty/base.rs
@@ -21,7 +21,6 @@ use std::ffi::OsString;
 use std::mem::MaybeUninit;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -407,8 +406,6 @@ pub struct PTYProcess {
     close_process: bool,
     /// Handle to the thread used to read from the standard output.
     reading_thread: Option<thread::JoinHandle<()>>,
-    /// Handle to the thread used to check if the process is alive.
-    alive_thread: Option<thread::JoinHandle<()>>,
     /// Channel used to keep the thread alive.
     reader_alive: Sender<bool>,
     /// Atomic variable to signal when a thread finishes
@@ -446,7 +443,6 @@ impl PTYProcess {
         conout: LocalHandle,
         using_pipes: bool,
         async_: bool,
-        cleanup_tx: Option<mpsc::Sender<bool>>,
     ) -> PTYProcess {
         let thread_arc = Arc::new(AtomicBool::new(true));
         let reader_arc = Arc::new(AtomicBool::new(false));
@@ -517,7 +513,6 @@ impl PTYProcess {
                 pid: 0,
                 close_process: true,
                 reading_thread: Some(reader_thread),
-                alive_thread: None,
                 reader_alive: reader_alive_tx,
                 reader_atomic: thread_arc,
                 reader_exit_event,
@@ -546,9 +541,7 @@ impl PTYProcess {
             let (reader_process_tx, reader_process_rx) = unbounded::<Option<LocalHandle>>();
             let spinlock_clone = Arc::clone(&thread_arc);
             let reader_ready = Arc::clone(&reader_arc);
-            let (reader_process_2_tx, reader_process_2_rx) = unbounded::<LocalHandle>();
             let reader_exit_for_thread = reader_exit_event;
-            let reader_exit_for_alive = reader_exit_event;
 
             let reader_thread = thread::spawn(move || {
                 let mut read_overlapped = OVERLAPPED::default();
@@ -565,8 +558,7 @@ impl PTYProcess {
 
                 let process_result = reader_process_rx.recv();
                 reader_ready.store(true, Ordering::Release);
-                if let Ok(Some(process)) = process_result {
-                    let _ = reader_process_2_tx.send(process);
+                if let Ok(Some(_process)) = process_result {
                     let mut alive = true;
                     while alive {
                         match read(true, conout.into(), using_pipes, Some(&mut read_overlapped)) {
@@ -594,38 +586,6 @@ impl PTYProcess {
                 drop(reader_process_rx);
                 drop(reader_alive_rx);
                 drop(reader_out_tx);
-                drop(reader_process_2_tx);
-            });
-
-            let alive_thread = thread::spawn(move || {
-                if let Ok(handle) = reader_process_2_rx.recv() {
-                    let _ = wait_for_exit(handle.into());
-                    unsafe {
-                        // Child has exited. Let modern ConPTY auto-close the output
-                        // pipe — reader's pending ReadFile then returns 0 bytes
-                        // (natural EOF) and the reader exits, signaling
-                        // `reader_exit_event`. If that doesn't happen in time
-                        // (older ConPTY / non-ConPTY consumer), fall back to
-                        // CancelIoEx to unstick the reader.
-                        let exit_handle = Into::<HANDLE>::into(reader_exit_for_alive);
-                        if WaitForSingleObject(exit_handle, 5000) != WAIT_OBJECT_0 {
-                            let _ = CancelIoEx(Into::<HANDLE>::into(conout), None);
-                            loop {
-                                if WaitForSingleObject(exit_handle, 50) == WAIT_OBJECT_0 {
-                                    break;
-                                }
-                                let _ = CancelIoEx(Into::<HANDLE>::into(conout), None);
-                            }
-                        }
-                        // Reader has drained and exited. Signal cleanup so the
-                        // consumer (e.g. ConPTY's cleanup_thread) can release
-                        // resources via ClosePseudoConsole.
-                        if let Some(tx) = cleanup_tx {
-                            let _ = tx.send(true).unwrap_or(());
-                        }
-                    }
-                }
-                drop(reader_process_2_rx);
             });
 
             PTYProcess {
@@ -635,7 +595,6 @@ impl PTYProcess {
                 pid: 0,
                 close_process: true,
                 reading_thread: Some(reader_thread),
-                alive_thread: Some(alive_thread),
                 reader_alive: reader_alive_tx,
                 reader_atomic: thread_arc,
                 reader_exit_event,
@@ -949,10 +908,6 @@ impl Drop for PTYProcess {
 
             if self.close_process && !self.process.is_invalid() {
                 let _ = CloseHandle(Into::<HANDLE>::into(self.process));
-            }
-
-            if let Some(thread_handle) = self.alive_thread.take() {
-                thread_handle.join().unwrap_or(());
             }
 
             if !self.reader_exit_event.is_invalid() {

--- a/src/pty/conpty/pty_impl.rs
+++ b/src/pty/conpty/pty_impl.rs
@@ -38,9 +38,8 @@ use std::ffi::{c_void, OsString};
 use std::mem::MaybeUninit;
 use std::ops::DerefMut;
 use std::os::windows::ffi::OsStrExt;
-use std::sync::{mpsc, Arc, Condvar, Mutex};
-use std::thread::JoinHandle;
-use std::{mem, ptr, thread};
+use std::sync::{Arc, Mutex};
+use std::{mem, ptr};
 
 use super::calls::{ClosePseudoConsole, CreatePseudoConsole, ResizePseudoConsole, ShowHidePseudoConsole};
 use crate::pty::PTYArgs;
@@ -54,24 +53,6 @@ pub struct ConPTY {
     startup_info: STARTUPINFOEXW,
     process: PTYProcess,
     console_allocated: bool,
-    release_info_tx: mpsc::Sender<(isize, isize, isize, isize, bool)>,
-    cleanup_thread: JoinHandle<()>,
-    cleanup_tx: mpsc::Sender<bool>
-}
-
-fn cleanup(
-    // startup_info: LPPROC_THREAD_ATTRIBUTE_LIST,
-    handle: isize,
-    console_allocated: bool,
-) {
-    unsafe {
-        // DeleteProcThreadAttributeList(startup_info);
-        let _ = ClosePseudoConsole(HPCON(handle));
-
-        if console_allocated {
-            let _ = FreeConsole();
-        }
-    }
 }
 
 unsafe impl Send for ConPTY {}
@@ -414,46 +395,14 @@ impl PTYImpl for ConPTY {
             // let _ = CloseHandle(input_read_side);
             // let _ = CloseHandle(output_write_side);
 
-            // let cleanup_callback = Arc::new((Mutex::<Option<Box<dyn Fn() + Send + 'static>>>::new(None), Condvar::new()));
-            let (cleanup_tx, cleanup_rx) = mpsc::channel::<bool>();
-            let (release_info_tx, release_info_rx) =
-                mpsc::channel::<(isize, isize, isize, isize, bool)>();
-
             let pty_process = PTYProcess::new(
                 server_pipe.into(),
                 server_pipe.into(),
                 true,
                 true,
-                Some(cleanup_tx.clone()),
             );
 
             let hpcon_mutex = Arc::new(Mutex::new((pty_handle, true)));
-            let hpcon_clone = Arc::clone(&hpcon_mutex);
-
-            let cleanup_thread = thread::spawn(move || {
-                match release_info_rx.recv() {
-                    Ok((_hthread_ptr, _hprocess_ptr, _startup_ptr, hpcon_ptr, console_allocated))=>{
-                        if let Ok(clean) = cleanup_rx.recv(){
-                            if clean {
-                                let mut hpcon_guard = hpcon_clone.lock().unwrap();
-                                if hpcon_guard.1 {
-                                    cleanup(
-                                        // LocalHandle(hthread_ptr as *mut c_void),
-                                        // LocalHandle(hprocess_ptr as *mut c_void),
-                                        // LPPROC_THREAD_ATTRIBUTE_LIST(startup_ptr as *mut c_void),
-                                        hpcon_guard.0.0,
-                                        console_allocated,
-                                    );
-                                    *hpcon_guard = (hpcon_guard.0, false);
-                                }
-                            }
-                        }
-                    },
-                    Err(_)=>{}
-                }
-                drop(cleanup_rx);
-                drop(release_info_rx);
-            });
 
             Ok(Box::new(ConPTY {
                 handle: hpcon_mutex,
@@ -461,9 +410,6 @@ impl PTYImpl for ConPTY {
                 startup_info: STARTUPINFOEXW::default(),
                 process: pty_process,
                 console_allocated,
-                release_info_tx,
-                cleanup_thread,
-                cleanup_tx
             }) as Box<dyn PTYImpl>)
         }
     }
@@ -587,6 +533,12 @@ impl PTYImpl for ConPTY {
             )
             .is_ok();
 
+            // The proc-thread attribute list is only needed during process
+            // creation. Free it now rather than carrying it to Drop. Matches
+            // Microsoft Terminal's lifetime handling.
+            DeleteProcThreadAttributeList(self.startup_info.lpAttributeList);
+            self.startup_info.lpAttributeList = LPPROC_THREAD_ATTRIBUTE_LIST(std::ptr::null_mut());
+
             if !succ {
                 result = Error::from_thread().into();
                 let result_msg = result.message();
@@ -595,15 +547,6 @@ impl PTYImpl for ConPTY {
             }
 
             self.process.set_process(self.process_info.hProcess, false);
-            self.release_info_tx
-                .send((
-                    self.process_info.hProcess.0 as isize,
-                    self.process_info.hThread.0 as isize,
-                    self.startup_info.lpAttributeList.0 as isize,
-                    handle.0.0,
-                    self.console_allocated,
-                ))
-                .unwrap();
             Ok(true)
         }
     }
@@ -674,8 +617,6 @@ impl PTYImpl for ConPTY {
 impl Drop for ConPTY {
     fn drop(&mut self) {
         unsafe {
-            self.cleanup_tx.send(false).unwrap_or(());
-
             if !self.process_info.hThread.is_invalid() {
                 let _ = CloseHandle(self.process_info.hThread);
             }
@@ -684,7 +625,12 @@ impl Drop for ConPTY {
                 let _ = CloseHandle(self.process_info.hProcess);
             }
 
-            DeleteProcThreadAttributeList(self.startup_info.lpAttributeList);
+            // If `spawn` was never called the attribute list is still allocated
+            // here; otherwise it was freed at the end of spawn and the pointer
+            // is null.
+            if !self.startup_info.lpAttributeList.is_invalid() {
+                DeleteProcThreadAttributeList(self.startup_info.lpAttributeList);
+            }
             let mut guard =  self.handle.lock().unwrap();
             if guard.1 {
                 let _ = ClosePseudoConsole(guard.0);

--- a/src/pty/winpty/pty_impl.rs
+++ b/src/pty/winpty/pty_impl.rs
@@ -223,7 +223,7 @@ impl PTYImpl for WinPTY {
             let conin = conin_res.unwrap();
             let conout = conout_res.unwrap();
 
-            let process = PTYProcess::new(conin.into(), conout.into(), false, false, None);
+            let process = PTYProcess::new(conin.into(), conout.into(), false, false);
             Ok(Box::new(WinPTY { ptr: pty_ptr, process }) as Box<dyn PTYImpl>)
         }
     }


### PR DESCRIPTION
## Summary

Microsoft Terminal's `ConptyConnection` doesn't run a separate child-process watcher or a separate ClosePseudoConsole-trigger thread. It relies on the reader thread seeing `ReadFile -> 0` (natural EOF) when conhost closes the output pipe, and calls `ClosePseudoConsole` directly from `Close()`. This PR brings winpty-rs in line with that pattern.

- Delete `alive_thread` from `PTYProcess` (field, spawn block, `reader_process_2` channel plumbing, `cleanup_tx` parameter on `PTYProcess::new`).
- Delete `cleanup_thread`, `cleanup_tx`/`cleanup_rx`, `release_info_tx`/`release_info_rx` from `ConPTY`. Their work is now done directly in `ConPTY::Drop`.
- Hoist `DeleteProcThreadAttributeList` from `Drop` into the end of `spawn` (Terminal does this at `ConptyConnection.cpp:123`). Null the field so Drop's defensive call skips when `spawn` actually ran.
- `Drop` order is unchanged in spirit: Drop body runs `CloseHandle(hThread/hProcess)` → `ClosePseudoConsole` → `FreeConsole`, then the `process: PTYProcess` field drops and the reader thread is joined. The reader sees natural EOF because `ClosePseudoConsole` has already closed the pipe.

Net: 16 inserted, 115 deleted, no behavior change for consumers.

## Stacks on top of

#120 (event-driven teardown)

## Test plan

- [x] `cargo test --features conpty --features winpty -- --test-threads=1` — all green
- [x] `pywinpty` test suite via local path-dependency: **40 passed, 4 xpassed**, 0 failures across both backends
- [ ] CI

## Correlation with Terminal

Verified against `microsoft/terminal` `ConptyConnection.cpp` / `.h`:

| Aspect | winpty-rs (this PR) | Terminal |
|---|---|---|
| Reader EOF detection | `ReadFile -> 0` | `ReadFile -> 0` |
| Separate process-death watcher | none | none |
| `ClosePseudoConsole` order | before reader join | before output-thread join |
| `DeleteProcThreadAttributeList` timing | end of spawn | line 123, after CreateProcessEx |
| `CancelIoEx` fallback | yes (timeout) | yes (timeout) |

The `CancelIoEx` retry-vs-single shape and the `FreeConsole`/`AllocConsole` usage remain different — both are pre-existing and out of scope for this PR.