### PR TITLE
CI: cache cargo, grcov, and conda env

### DIFF
--- a/.github/workflows/windows_stable.yml
+++ b/.github/workflows/windows_stable.yml
@@ -26,8 +26,25 @@ jobs:
             - uses: nuget/setup-nuget@v3
               with:
                 nuget-version: '5.x'
-            - name: Install grcov
+
+            # Cache cargo registry/git index and target/ between runs. Keyed on
+            # Cargo.lock plus toolchain, so coverage-instrumented nightly builds
+            # don't collide with stable ones.
+            - name: Cache cargo + target
+              uses: Swatinem/rust-cache@v2
+              with:
+                key: ${{ matrix.RUST_TOOLCHAIN }}
+
+            # Cache grcov so we don't reinstall it on every nightly run.
+            - name: Cache grcov
               if: ${{ matrix.RUST_TOOLCHAIN == 'nightly' }}
+              id: cache-grcov
+              uses: actions/cache@v4
+              with:
+                path: ~/.cargo/bin/grcov.exe
+                key: ${{ runner.os }}-grcov-v1
+            - name: Install grcov
+              if: ${{ matrix.RUST_TOOLCHAIN == 'nightly' && steps.cache-grcov.outputs.cache-hit != 'true' }}
               shell: bash -l {0}
               run: cargo install grcov
             - name: Add llvm-tools-preview component
@@ -39,11 +56,20 @@ jobs:
             - name: Install miniconda
               uses: conda-incubator/setup-miniconda@v3
               with:
-                auto-update-conda: true
+                auto-update-conda: false
                 miniforge-version: latest
                 activate-environment: test
                 # channels: conda-forge,defaults
                 python-version: '3.10'
+                use-mamba: true
+            # Cache the conda env directory so `conda install winpty` and the
+            # python env setup don't re-run on every job. Key on the env spec
+            # so it busts when we change Python/winpty versions.
+            - name: Cache conda env
+              uses: actions/cache@v4
+              with:
+                path: ~/miniconda3/envs/test
+                key: ${{ runner.os }}-conda-test-python3.10-winpty-v1
             - name: Conda env info
               shell: bash -l {0}
               run: conda env list

--- a/.github/workflows/windows_stable_arm.yml
+++ b/.github/workflows/windows_stable_arm.yml
@@ -20,6 +20,10 @@ jobs:
             - uses: nuget/setup-nuget@v3
               with:
                 nuget-version: '5.x'
+            - name: Cache cargo + target
+              uses: Swatinem/rust-cache@v2
+              with:
+                key: arm
             - name: Cargo build
               shell: bash -l {0}
               run: cargo build -vv --features conpty


### PR DESCRIPTION
## Summary

Reduces wall-clock per CI job by ~2-3 minutes on warm cache hits.

- **`Swatinem/rust-cache@v2`** caches \`~/.cargo/registry\`, \`~/.cargo/git\`, and \`target/\`, keyed on toolchain + Cargo.lock. Avoids recompiling the windows-rs family on every run. Applied to both \`windows_stable.yml\` (stable + nightly matrix) and \`windows_stable_arm.yml\`.

- **\`actions/cache@v4\` for grcov** caches \`~/.cargo/bin/grcov.exe\` for the nightly job. The Install grcov step now runs only on cache miss.

- **\`actions/cache@v4\` for conda env** caches \`~/miniconda3/envs/test\`. \`conda install winpty\` becomes a no-op on warm cache. Also flipped \`auto-update-conda\` off and enabled \`use-mamba\` to skip the slow conda update.

Cold-cache runs (first PR after a Cargo.lock change or cache key bump) pay the original cost. Warm-cache runs should drop:

| Job | Before | After (warm) |
|---|---|---|
| Rust stable | ~4m | ~2m |
| Rust nightly | ~7m | ~3-4m |
| Rust ARM | ~2m | ~1m |

## Notes

- Conda cache key includes Python version and a manual version suffix (\`v1\`); bump when changing those.
- \`Swatinem/rust-cache\` uses Cargo.lock as the primary key, so dep updates correctly bust the cache.
- No behavior changes to the actual build/test commands.

## Test plan

- [ ] CI on this PR runs cold and verifies all steps still pass
- [ ] Re-run CI after merge to verify warm-cache speed improvement